### PR TITLE
프로젝트 관리 앱 [STEP 2-3] 지성, 제인

### DIFF
--- a/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
+++ b/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1366EC08AC994F9DCCF2EE95 /* Pods_ProjectManagerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2BC4EF963D2B452EAEBA8F3 /* Pods_ProjectManagerTests.framework */; };
 		70C75EF4C0698925773860FB /* Pods_ProjectManager.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 13E353B5FABF07E6030E5DDB /* Pods_ProjectManager.framework */; };
+		A615758027ECB98F00F9FB62 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A615757F27ECB98E00F9FB62 /* ViewModelType.swift */; };
 		A62BB67D27D1B532009395D8 /* UITableView+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62BB67C27D1B532009395D8 /* UITableView+extension.swift */; };
 		A6541F6D27CF3A3900F576D4 /* ProjectListTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6541F6C27CF3A3900F576D4 /* ProjectListTableView.swift */; };
 		A6541F6F27CF3AC600F576D4 /* ProjectListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6541F6E27CF3AC600F576D4 /* ProjectListTableViewCell.swift */; };
@@ -53,6 +54,7 @@
 		1EFDCFB1981E5910DB11494D /* Pods-ProjectManager.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProjectManager.debug.xcconfig"; path = "Target Support Files/Pods-ProjectManager/Pods-ProjectManager.debug.xcconfig"; sourceTree = "<group>"; };
 		416D60185AC222D4405EC374 /* Pods-ProjectManager.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProjectManager.release.xcconfig"; path = "Target Support Files/Pods-ProjectManager/Pods-ProjectManager.release.xcconfig"; sourceTree = "<group>"; };
 		9FF5E0D96C5531AEE7F6FAEF /* Pods-ProjectManagerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProjectManagerTests.release.xcconfig"; path = "Target Support Files/Pods-ProjectManagerTests/Pods-ProjectManagerTests.release.xcconfig"; sourceTree = "<group>"; };
+		A615757F27ECB98E00F9FB62 /* ViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelType.swift; sourceTree = "<group>"; };
 		A62BB67C27D1B532009395D8 /* UITableView+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+extension.swift"; sourceTree = "<group>"; };
 		A6541F6C27CF3A3900F576D4 /* ProjectListTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectListTableView.swift; sourceTree = "<group>"; };
 		A6541F6E27CF3AC600F576D4 /* ProjectListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectListTableViewCell.swift; sourceTree = "<group>"; };
@@ -253,6 +255,7 @@
 		EA4C970B27D70EF9002929B8 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				A615757F27ECB98E00F9FB62 /* ViewModelType.swift */,
 				EA4C970227D5EFBF002929B8 /* ProjectListViewModel.swift */,
 				EA03AB5C27E20C1700084E75 /* EditProjectDetailViewModel.swift */,
 				EA03AB5E27E234B200084E75 /* AddProjectDetailViewModel.swift */,
@@ -437,6 +440,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A615758027ECB98F00F9FB62 /* ViewModelType.swift in Sources */,
 				EA4C970327D5EFBF002929B8 /* ProjectListViewModel.swift in Sources */,
 				EA03ABC927E31BCD00084E75 /* Collection+extension.swift in Sources */,
 				EA03AB5427E071CD00084E75 /* Date+extension.swift in Sources */,

--- a/ProjectManager/ProjectManager/Domain/ProjectUseCase.swift
+++ b/ProjectManager/ProjectManager/Domain/ProjectUseCase.swift
@@ -1,32 +1,33 @@
 import Foundation
+import RxSwift
+import RxRelay
 
 protocol ProjectUseCaseProtocol {
     func fetch(with id: UUID) -> Project
-    func fetchAll() -> [Project]
+    func bindProjects() -> Observable<[Project]>
     func append(_ project: Project)
     func update(_ project: Project, to state: ProjectState?)
     func delete(_ project: Project)
 }
 
 final class ProjectUseCase: ProjectUseCaseProtocol {
+    let disposeBag = DisposeBag()
     let projectRepository: ProjectRepositoryProtocol
     
     init(repository: ProjectRepositoryProtocol) {
         self.projectRepository = repository
     }
 
-    func fetchAll() -> [Project] {
-        return projectRepository.fetchAll()
-            .map { $0.value }
-            .sorted { $0.date > $1.date }
+    func bindProjects() -> Observable<[Project]> {
+        return projectRepository.bindProjects()
+            .map {
+                $0.map { $0.value }
+                .sorted { $0.date > $1.date }
+            }
     }
     
     func fetch(with id: UUID) -> Project {
-        let fetchedData = projectRepository.fetchAll()
-        
-        return fetchedData
-            .map { $0.value }
-            .filter{ $0.id == id }.first!
+        return Project(id: id, state: .todo, title: "aa", body: "aa", date: Date()) //임시
     }
     
     func append(_ project: Project) {

--- a/ProjectManager/ProjectManager/Domain/ProjectUseCase.swift
+++ b/ProjectManager/ProjectManager/Domain/ProjectUseCase.swift
@@ -3,7 +3,7 @@ import RxSwift
 import RxRelay
 
 protocol ProjectUseCaseProtocol {
-    func fetch(with id: UUID) -> Project
+    func fetch(with id: UUID) -> Project?
     func bindProjects() -> Observable<[Project]>
     func append(_ project: Project)
     func update(_ project: Project, to state: ProjectState?)
@@ -26,8 +26,8 @@ final class ProjectUseCase: ProjectUseCaseProtocol {
             }
     }
     
-    func fetch(with id: UUID) -> Project {
-        return Project(id: id, state: .todo, title: "aa", body: "aa", date: Date()) //임시
+    func fetch(with id: UUID) -> Project? {
+        return projectRepository.bindProjects().value[id]
     }
     
     func append(_ project: Project) {
@@ -35,7 +35,9 @@ final class ProjectUseCase: ProjectUseCaseProtocol {
     }
     
     func update(_ project: Project, to state: ProjectState?) {
-        let oldProject = fetch(with: project.id)
+        guard let oldProject = fetch(with: project.id) else {
+            return
+        }
         var newProject = oldProject
         
         if let updatedState = state {

--- a/ProjectManager/ProjectManager/Repository/ProjectRepository.swift
+++ b/ProjectManager/ProjectManager/Repository/ProjectRepository.swift
@@ -1,7 +1,9 @@
 import Foundation
+import RxSwift
+import RxRelay
 
 protocol ProjectRepositoryProtocol {
-    func fetchAll() -> [UUID: Project]
+    func bindProjects() -> BehaviorRelay<[UUID: Project]>
     func append(_ project: Project)
     func update(_ project: Project)
     func delete(_ project: Project)
@@ -10,25 +12,30 @@ protocol ProjectRepositoryProtocol {
 final class ProjectRepository: ProjectRepositoryProtocol {
     let id = [UUID(), UUID(), UUID(), UUID()] // 테스트용
     
-    private lazy var projects = [id[0]: Project(id: id[0], state: .todo, title: "투두", body: "앞으로 해야할 일", date: Date(timeIntervalSince1970: 1000)),
-                             id[1]: Project(id: id[1], state: .doing, title: "두잉", body: "아직도 끝나지 않은 일들", date: Date(timeIntervalSince1970: 1000)),
-                             id[2]: Project(id: id[2], state: .done, title: "돈", body: "여기에는 기한이 지난 할일의 내용이 나오는 곳입니다.", date: Date(timeIntervalSince1970: 1000)),
-                             id[3]:Project(id: id[3], state: .done, title: "이미 끝난 일", body: "오늘 할 일을 내일로 미루지 말자.", date: Date(timeIntervalSince1970: 1000))] // 테스트용
+    private lazy var projects = BehaviorRelay<[UUID: Project]>(value: [id[0]: Project(id: id[0], state: .todo, title: "투두", body: "앞으로 해야할 일", date: Date(timeIntervalSince1970: 1000)),
+                                                                 id[1]: Project(id: id[1], state: .doing, title: "두잉", body: "아직도 끝나지 않은 일들", date: Date(timeIntervalSince1970: 1000)),
+                                                                 id[2]: Project(id: id[2], state: .done, title: "돈", body: "여기에는 기한이 지난 할일의 내용이 나오는 곳입니다.", date: Date(timeIntervalSince1970: 1000)),
+                                                                 id[3]:Project(id: id[3], state: .done, title: "이미 끝난 일", body: "오늘 할 일을 내일로 미루지 말자.", date: Date(timeIntervalSince1970: 1000))])
     
-    func fetchAll() -> [UUID: Project] {
+    func bindProjects() -> BehaviorRelay<[UUID: Project]> {
         return projects
     }
     
     func append(_ project: Project) {
-        projects[project.id] = project
-        print(project.title)
+        var currentProjects = projects.value
+        currentProjects[project.id] = project
+        projects.accept(currentProjects)
     }
     
     func update(_ project: Project) {
-        projects.updateValue(project, forKey: project.id)
+        var currentProjects = projects.value
+        currentProjects.updateValue(project, forKey: project.id)
+        projects.accept(currentProjects)
     }
     
     func delete(_ project: Project) {
-        projects.removeValue(forKey: project.id)
+        var currentProjects = projects.value
+        currentProjects.removeValue(forKey: project.id)
+        projects.accept(currentProjects)
     }
 }

--- a/ProjectManager/ProjectManager/Repository/ProjectRepository.swift
+++ b/ProjectManager/ProjectManager/Repository/ProjectRepository.swift
@@ -21,6 +21,7 @@ final class ProjectRepository: ProjectRepositoryProtocol {
     
     func append(_ project: Project) {
         projects[project.id] = project
+        print(project.title)
     }
     
     func update(_ project: Project) {

--- a/ProjectManager/ProjectManager/View/ProjectDetailView/AddProjectDetailViewController.swift
+++ b/ProjectManager/ProjectManager/View/ProjectDetailView/AddProjectDetailViewController.swift
@@ -5,6 +5,8 @@ import RxCocoa
 final class AddProjectDetailViewController: ProjectDetailViewController {
     weak var delegate: ProjectDetailViewControllerDelegate?
     var viewModel: AddProjectDetailViewModel?
+    private let disposeBag = DisposeBag()
+    
     
     private let doneButton: UIBarButtonItem = {
         let button = UIBarButtonItem(barButtonSystemItem: .done, target: AddProjectDetailViewController.self, action: nil)
@@ -16,10 +18,9 @@ final class AddProjectDetailViewController: ProjectDetailViewController {
         return button
     }()
     
-    init(viewModel: AddProjectDetailViewModel, delegate: ProjectDetailViewControllerDelegate) {
+    init(viewModel: AddProjectDetailViewModel) {
         super.init(nibName: nil, bundle: nil)
         self.viewModel = viewModel
-        self.delegate = delegate
     }
     
     required init?(coder: NSCoder) {
@@ -29,10 +30,8 @@ final class AddProjectDetailViewController: ProjectDetailViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureNavigationBar()
-        bind()
-//        viewModel?.onAppended = { project in
-//            self.delegate?.didAppendProject(project)
-//        }
+        cofigureBind()
+        cofigureNavigationItemBind()
     }
     
     private func configureNavigationBar() {
@@ -42,25 +41,26 @@ final class AddProjectDetailViewController: ProjectDetailViewController {
         navigationController?.navigationBar.backgroundColor = .systemGray6
     }
     
-    func bind() {
+    func cofigureBind() {
         let input = AddProjectDetailViewModel.Input(didTapdoneButton: doneButton.rx.tap.asObservable(),
                                                     projectTitle: projectDetailView.titleTextField.rx.text.orEmpty.asObservable(),
                                                     projectBody: projectDetailView.bodyTextView.rx.text.orEmpty.asObservable(),
                                                     projectDate: projectDetailView.datePicker.rx.date.asObservable())
         
-        let output = viewModel?.transform(input: input)
+        _ = viewModel?.transform(input: input)
     }
-//
-//    @objc private func didTapDoneButton() {
-//        self.dismiss(animated: true) {
-//            let project = self.createViewData()
-//            self.viewModel?.didTapDoneButton(project)
-//        }
-//    }
-//
-//    @objc private func didTapCancelButton() {
-//        self.dismiss(animated: true, completion: nil)
-//    }
+    
+    func cofigureNavigationItemBind() {
+        doneButton.rx.tap
+            .subscribe(onNext: { [weak self] in
+                self?.dismiss(animated: true)
+            }).disposed(by: disposeBag)
+        
+        cancelButton.rx.tap
+            .subscribe(onNext: { [weak self] in
+                self?.dismiss(animated: true)
+            }).disposed(by: disposeBag)
+    }
 }
 
 //MARK: - Constants

--- a/ProjectManager/ProjectManager/View/ProjectDetailView/AddProjectDetailViewController.swift
+++ b/ProjectManager/ProjectManager/View/ProjectDetailView/AddProjectDetailViewController.swift
@@ -3,7 +3,6 @@ import RxSwift
 import RxCocoa
 
 final class AddProjectDetailViewController: ProjectDetailViewController {
-    weak var delegate: ProjectDetailViewControllerDelegate?
     var viewModel: AddProjectDetailViewModel?
     private let disposeBag = DisposeBag()
     

--- a/ProjectManager/ProjectManager/View/ProjectDetailView/AddProjectDetailViewController.swift
+++ b/ProjectManager/ProjectManager/View/ProjectDetailView/AddProjectDetailViewController.swift
@@ -1,8 +1,20 @@
 import UIKit
+import RxSwift
+import RxCocoa
 
 final class AddProjectDetailViewController: ProjectDetailViewController {
     weak var delegate: ProjectDetailViewControllerDelegate?
     var viewModel: AddProjectDetailViewModel?
+    
+    private let doneButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(barButtonSystemItem: .done, target: AddProjectDetailViewController.self, action: nil)
+        return button
+    }()
+    
+    private let cancelButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(barButtonSystemItem: .cancel, target: AddProjectDetailViewController.self, action: nil)
+        return button
+    }()
     
     init(viewModel: AddProjectDetailViewModel, delegate: ProjectDetailViewControllerDelegate) {
         super.init(nibName: nil, bundle: nil)
@@ -17,28 +29,38 @@ final class AddProjectDetailViewController: ProjectDetailViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureNavigationBar()
-        viewModel?.onAppended = { project in
-            self.delegate?.didAppendProject(project)
-        }
+        bind()
+//        viewModel?.onAppended = { project in
+//            self.delegate?.didAppendProject(project)
+//        }
     }
     
     private func configureNavigationBar() {
         self.navigationItem.title = TitleText.navigationBarTitle
-        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(didTapDoneButton))
-        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(didTapCancelButton))
+        navigationItem.rightBarButtonItem = doneButton
+        navigationItem.leftBarButtonItem = cancelButton
         navigationController?.navigationBar.backgroundColor = .systemGray6
     }
     
-    @objc private func didTapDoneButton() {
-        self.dismiss(animated: true) {
-            let project = self.createViewData()
-            self.viewModel?.didTapDoneButton(project)
-        }
+    func bind() {
+        let input = AddProjectDetailViewModel.Input(didTapdoneButton: doneButton.rx.tap.asObservable(),
+                                                    projectTitle: projectDetailView.titleTextField.rx.text.orEmpty.asObservable(),
+                                                    projectBody: projectDetailView.bodyTextView.rx.text.orEmpty.asObservable(),
+                                                    projectDate: projectDetailView.datePicker.rx.date.asObservable())
+        
+        let output = viewModel?.transform(input: input)
     }
-    
-    @objc private func didTapCancelButton() {
-        self.dismiss(animated: true, completion: nil)
-    }
+//
+//    @objc private func didTapDoneButton() {
+//        self.dismiss(animated: true) {
+//            let project = self.createViewData()
+//            self.viewModel?.didTapDoneButton(project)
+//        }
+//    }
+//
+//    @objc private func didTapCancelButton() {
+//        self.dismiss(animated: true, completion: nil)
+//    }
 }
 
 //MARK: - Constants

--- a/ProjectManager/ProjectManager/View/ProjectDetailView/EditProjectDetailViewController.swift
+++ b/ProjectManager/ProjectManager/View/ProjectDetailView/EditProjectDetailViewController.swift
@@ -1,11 +1,6 @@
 import UIKit
 import RxSwift
 
-protocol ProjectDetailViewControllerDelegate: AnyObject {
-    func didUpdateProject(_ project: Project)
-    func didAppendProject(_ project: Project)
-}
-
 final class EditProjectDetailViewController: ProjectDetailViewController {
     private let disposeBag = DisposeBag()
     var viewModel: EditProjectDetailViewModel?
@@ -29,7 +24,6 @@ final class EditProjectDetailViewController: ProjectDetailViewController {
         populateView(with: viewModel?.currentProject)
         configureNavigationBar()
         projectDetailView.setEditingMode(to: false)
-    
         configureBind()
     }
     
@@ -43,10 +37,10 @@ final class EditProjectDetailViewController: ProjectDetailViewController {
     private func configureBind() {
         let didTapButtonObservable = editButtonItem.rx.tap
             .do(onNext: { [weak self] in self?.toggleEditMode() })
-                .asObservable()
-//            .subscribe(onNext: { [weak self] in
-//                self?.toggleEditMode()
-//            }).disposed(by: disposeBag)
+            .scan(false) { lastState, _ in
+                !lastState
+            }
+            .asObservable()
         
         cancelButton.rx.tap
             .subscribe(onNext: { [weak self] in

--- a/ProjectManager/ProjectManager/View/ProjectListView/ProjectListTableView.swift
+++ b/ProjectManager/ProjectManager/View/ProjectListView/ProjectListTableView.swift
@@ -1,10 +1,7 @@
 import UIKit
 
 final class ProjectListTableView: UITableView {
-    var state: ProjectState?
-
-    init(state: ProjectState) {
-        self.state = state
+    init() {
         super.init(frame: .zero, style: .plain)
         configureUI()
     }

--- a/ProjectManager/ProjectManager/View/ProjectListView/ProjectListViewController.swift
+++ b/ProjectManager/ProjectManager/View/ProjectListView/ProjectListViewController.swift
@@ -6,7 +6,7 @@ final class ProjectListViewController: UIViewController {
     private let todoTableView = ProjectListTableView()
     private let doingTableView = ProjectListTableView()
     private let doneTableView = ProjectListTableView()
-    private var viewModel: ProjectListViewModelProtocol?
+    private var viewModel: ProjectListViewModel?
     private lazy var tableViews = [todoTableView, doingTableView, doneTableView]
     
     private let entireStackView: UIStackView = {
@@ -19,7 +19,7 @@ final class ProjectListViewController: UIViewController {
         return stackView
     }()
     
-    init(viewModel: ProjectListViewModelProtocol) {
+    init(viewModel: ProjectListViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }

--- a/ProjectManager/ProjectManager/View/ProjectListView/ProjectListViewController.swift
+++ b/ProjectManager/ProjectManager/View/ProjectListView/ProjectListViewController.swift
@@ -70,7 +70,7 @@ final class ProjectListViewController: UIViewController {
         
         output?.todoProjects
             .do(onNext: { [weak self] in
-                (self?.todoTableView.tableHeaderView as? ProjectListTableHeaderView)?.populateData(title: $0.first?.state.title ?? "",  count: $0.count)
+                (self?.todoTableView.tableHeaderView as? ProjectListTableHeaderView)?.populateData(title: $0.first?.state.title ?? "TODO",  count: $0.count)
             })
             .asDriver(onErrorJustReturn: [])
             .drive(
@@ -88,7 +88,7 @@ final class ProjectListViewController: UIViewController {
 
         output?.doingProjects
             .do(onNext: { [weak self] in
-                (self?.doingTableView.tableHeaderView as? ProjectListTableHeaderView)?.populateData(title: $0.first?.state.title ?? "", count: $0.count)
+                (self?.doingTableView.tableHeaderView as? ProjectListTableHeaderView)?.populateData(title: $0.first?.state.title ?? "DOING", count: $0.count)
             })
             .asDriver(onErrorJustReturn: [])
             .drive(
@@ -106,7 +106,7 @@ final class ProjectListViewController: UIViewController {
 
         output?.doneProjects
             .do(onNext: { [weak self] in
-                (self?.doneTableView.tableHeaderView as? ProjectListTableHeaderView)?.populateData(title: $0.first?.state.title ?? "", count: $0.count)
+                (self?.doneTableView.tableHeaderView as? ProjectListTableHeaderView)?.populateData(title: $0.first?.state.title ?? "DONE", count: $0.count)
             })
             .asDriver(onErrorJustReturn: [])
             .drive(
@@ -151,6 +151,13 @@ final class ProjectListViewController: UIViewController {
                     
                     destinationViewController.modalPresentationStyle = .formSheet
                     self?.present(destinationViewController, animated: true, completion: nil)
+                }).disposed(by: disposeBag)
+        }
+        
+        tableViews.forEach {
+            $0.rx.modelDeleted(Project.self)
+                .subscribe(onNext: { [weak self] project in
+                    self?.viewModel?.delete(project: project)
                 }).disposed(by: disposeBag)
         }
     }
@@ -271,12 +278,3 @@ private extension ProjectListViewController {
     }
 }
 
-extension ProjectListViewController: ProjectDetailViewControllerDelegate {
-    func didUpdateProject(_ project: Project) {
-        viewModel?.update(project, state: nil)
-    }
-    
-    func didAppendProject(_ project: Project) {
-        viewModel?.append(project)
-    }
-}

--- a/ProjectManager/ProjectManager/View/ProjectListView/ProjectListViewController.swift
+++ b/ProjectManager/ProjectManager/View/ProjectListView/ProjectListViewController.swift
@@ -3,9 +3,9 @@ import UIKit
 final class ProjectListViewController: UIViewController {
     // MARK: - Property
     
-    private let todoTableView = ProjectListTableView(state: .todo)
-    private let doingTableView = ProjectListTableView(state: .doing)
-    private let doneTableView = ProjectListTableView(state: .done)
+    private let todoTableView = ProjectListTableView()
+    private let doingTableView = ProjectListTableView()
+    private let doneTableView = ProjectListTableView()
     private var viewModel: ProjectListViewModelProtocol?
     private lazy var tableViews = [todoTableView, doingTableView, doneTableView]
     
@@ -146,8 +146,24 @@ final class ProjectListViewController: UIViewController {
         }
     }
     
+    func state(of tableView: UITableView) -> ProjectState? {
+        var state: ProjectState?
+        switch tableView {
+        case todoTableView:
+            state = .todo
+        case doingTableView:
+            state = .doing
+        case doneTableView:
+            state = .done
+        default:
+            break
+        }
+        
+        return state
+    }
+    
     private func createAlert(for tableView: UITableView, on indexPath: IndexPath, moveTo newState: [ProjectState]) -> UIAlertController? {
-        guard let oldState = ((tableView as? ProjectListTableView)?.state),
+        guard let oldState = state(of: tableView),
                 let firstNewState = newState[safe: 0],
                 let secondNewState = newState[safe: 1] else {
             return nil
@@ -183,8 +199,8 @@ extension ProjectListViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard let state = (tableView as? ProjectListTableView)?.state else {
-            return UIView()
+        guard let state = state(of: tableView) else {
+            return nil
         }
         let numberOfProjects = viewModel?.numberOfProjects(state: state)
         
@@ -196,7 +212,7 @@ extension ProjectListViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let deleteAction = UIContextualAction(style: .destructive, title: nil) { _, _, _ in
-            guard let state = (tableView as? ProjectListTableView)?.state else {
+            guard let state = self.state(of: tableView) else {
                 return
             }
             self.viewModel?.delete(indexPath: indexPath, state: state)
@@ -208,7 +224,7 @@ extension ProjectListViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let state = (tableView as? ProjectListTableView)?.state else {
+        guard let state = state(of: tableView) else {
             return
         }
         viewModel?.didSelectRow(indexPath: indexPath, state: state)
@@ -217,7 +233,7 @@ extension ProjectListViewController: UITableViewDelegate {
 
 extension ProjectListViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        guard let state = (tableView as? ProjectListTableView)?.state else {
+        guard let state = state(of: tableView) else {
             return .zero
         }
     
@@ -232,7 +248,7 @@ extension ProjectListViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let state = ((tableView as? ProjectListTableView)?.state),
+        guard let state = state(of: tableView),
               let project = viewModel?.retrieveSelectedData(indexPath: indexPath, state: state),
               let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date()) else {
             return UITableViewCell()

--- a/ProjectManager/ProjectManager/ViewModel/AddProjectDetailViewModel.swift
+++ b/ProjectManager/ProjectManager/ViewModel/AddProjectDetailViewModel.swift
@@ -2,12 +2,6 @@ import Foundation
 import RxSwift
 
 final class AddProjectDetailViewModel: ViewModelType {
-    private let useCase: ProjectUseCaseProtocol?
-    private let disposeBag = DisposeBag()
-    init(useCase: ProjectUseCaseProtocol) {
-        self.useCase = useCase
-    }
-    
     struct Input {
         let didTapdoneButton: Observable<Void>
         let projectTitle: Observable<String>
@@ -17,6 +11,13 @@ final class AddProjectDetailViewModel: ViewModelType {
     
     struct Output {}
     
+    private let useCase: ProjectUseCaseProtocol?
+    private let disposeBag = DisposeBag()
+    
+    init(useCase: ProjectUseCaseProtocol) {
+        self.useCase = useCase
+    }
+
     func transform(input: Input) -> Output {
         let projectDetail = Observable.combineLatest(input.projectTitle, input.projectBody, input.projectDate)
         

--- a/ProjectManager/ProjectManager/ViewModel/AddProjectDetailViewModel.swift
+++ b/ProjectManager/ProjectManager/ViewModel/AddProjectDetailViewModel.swift
@@ -15,14 +15,12 @@ final class AddProjectDetailViewModel: ViewModelType {
         let projectDate: Observable<Date>
     }
     
-    struct Output {
-        
-    }
+    struct Output {}
     
     func transform(input: Input) -> Output {
         let projectDetail = Observable.combineLatest(input.projectTitle, input.projectBody, input.projectDate)
         
-        let create = input.didTapdoneButton.withLatestFrom(projectDetail)
+        input.didTapdoneButton.withLatestFrom(projectDetail)
             .map { (title, body, date) in
                 return Project(id: UUID(), state: .todo, title: title, body: body, date: date)
             }
@@ -32,11 +30,5 @@ final class AddProjectDetailViewModel: ViewModelType {
             }).disposed(by: disposeBag)
         
         return Output()
-    }
-    
-    var onAppended: ((Project) -> Void)?
-    
-    func didTapDoneButton(_ project: Project) {
-        onAppended?(project)
     }
 }

--- a/ProjectManager/ProjectManager/ViewModel/AddProjectDetailViewModel.swift
+++ b/ProjectManager/ProjectManager/ViewModel/AddProjectDetailViewModel.swift
@@ -1,6 +1,39 @@
 import Foundation
+import RxSwift
 
-class AddProjectDetailViewModel {
+final class AddProjectDetailViewModel: ViewModelType {
+    private let useCase: ProjectUseCaseProtocol?
+    private let disposeBag = DisposeBag()
+    init(useCase: ProjectUseCaseProtocol) {
+        self.useCase = useCase
+    }
+    
+    struct Input {
+        let didTapdoneButton: Observable<Void>
+        let projectTitle: Observable<String>
+        let projectBody: Observable<String>
+        let projectDate: Observable<Date>
+    }
+    
+    struct Output {
+        
+    }
+    
+    func transform(input: Input) -> Output {
+        let projectDetail = Observable.combineLatest(input.projectTitle, input.projectBody, input.projectDate)
+        
+        let create = input.didTapdoneButton.withLatestFrom(projectDetail)
+            .map { (title, body, date) in
+                return Project(id: UUID(), state: .todo, title: title, body: body, date: date)
+            }
+            .compactMap { $0 }
+            .subscribe(onNext: { [weak self] project in
+                self?.useCase?.append(project)
+            }).disposed(by: disposeBag)
+        
+        return Output()
+    }
+    
     var onAppended: ((Project) -> Void)?
     
     func didTapDoneButton(_ project: Project) {

--- a/ProjectManager/ProjectManager/ViewModel/EditProjectDetailViewModel.swift
+++ b/ProjectManager/ProjectManager/ViewModel/EditProjectDetailViewModel.swift
@@ -3,7 +3,7 @@ import RxSwift
 
 class EditProjectDetailViewModel: ViewModelType {
     struct Input {
-        let didTapDoneButton: Observable<Void>
+        let didTapDoneButton: Observable<Bool>
     }
     
     struct Output {
@@ -21,8 +21,11 @@ class EditProjectDetailViewModel: ViewModelType {
     
     func transform(input: Input) -> Output {
         input.didTapDoneButton
-            .subscribe(onNext: { [weak self] in
-                self?.usecase.update(self?.currentProject ?? Project(id: UUID(), state: .todo, title: "", body: "", date: Date()), to: nil)
+            .subscribe(onNext: { [weak self] value in
+                if value == false {
+                    self?.usecase.update(self?.currentProject ?? Project(id: UUID(), state: .todo, title: "", body: "", date: Date()), to: nil)
+                }
+                
             }).disposed(by: disposeBag)
         
         let output = Output()

--- a/ProjectManager/ProjectManager/ViewModel/EditProjectDetailViewModel.swift
+++ b/ProjectManager/ProjectManager/ViewModel/EditProjectDetailViewModel.swift
@@ -1,14 +1,31 @@
 import Foundation
+import RxSwift
 
-class EditProjectDetailViewModel {
-    var currentProject: Project
-    var onUpdated: ((Project) -> Void)?
+class EditProjectDetailViewModel: ViewModelType {
+    struct Input {
+        let didTapDoneButton: Observable<Void>
+    }
     
-    init(currentProject: Project) {
+    struct Output {
+    
+    }
+    
+    let usecase: ProjectUseCaseProtocol
+    let disposeBag = DisposeBag()
+    var currentProject: Project
+    
+    init(usecase: ProjectUseCaseProtocol, currentProject: Project) {
+        self.usecase = usecase
         self.currentProject = currentProject
     }
     
-    func didTapDoneButton(_ project: Project) {
-        onUpdated?(project)
+    func transform(input: Input) -> Output {
+        input.didTapDoneButton
+            .subscribe(onNext: { [weak self] in
+                self?.usecase.update(self?.currentProject ?? Project(id: UUID(), state: .todo, title: "", body: "", date: Date()), to: nil)
+            }).disposed(by: disposeBag)
+        
+        let output = Output()
+        return output
     }
 }

--- a/ProjectManager/ProjectManager/ViewModel/ProjectListViewModel.swift
+++ b/ProjectManager/ProjectManager/ViewModel/ProjectListViewModel.swift
@@ -1,108 +1,61 @@
 import UIKit
+import RxSwift
 
 final class ProjectListViewModel: ViewModelType {
-    final class Input {
-//        let doneButton
+    struct Input {
+
     }
     
-    final class Output {
-        
+    struct Output {
+        let todoProjects: Observable<[Project]>
+        let doingProjects: Observable<[Project]>
+        let doneProjects: Observable<[Project]>
     }
     
     func transform(input: Input) -> Output {
-        return Output()
+        let todoProjects = useCase.bindProjects()
+            .map { $0.filter { $0.state == .todo }}
+        
+        let doingProjects = useCase.bindProjects()
+            .map { $0.filter { $0.state == .doing }}
+        
+        let doneProjects = useCase.bindProjects()
+            .map { $0.filter { $0.state == .done }}
+        
+        return Output(todoProjects: todoProjects,
+                      doingProjects: doingProjects,
+                      doneProjects: doneProjects)
     }
     
     let useCase: ProjectUseCaseProtocol
-    
-    var onCellSelected: ((IndexPath, Project) -> Void)?
-    var onUpdated: (() -> Void)?
     
     init(useCase: ProjectUseCaseProtocol) {
         self.useCase = useCase
     }
     
-    private var projects: [Project] = [] {
-        didSet {
-            onUpdated?()
-        }
-    }
-    
-    var todoProjects: [Project] {
-        projects.filter { $0.state == .todo }
-    }
-    
-    var doingProjects: [Project] {
-        projects.filter { $0.state == .doing }
-    }
-    
-    var doneProjects: [Project] {
-        projects.filter { $0.state == .done }
-    }
-    
     func retrieveSelectedData(indexPath: IndexPath, state: ProjectState) -> Project? {
-        var selectedProject: Project?
-        switch state {
-        case .todo:
-            selectedProject = todoProjects[indexPath.row]
-        case .doing:
-            selectedProject = doingProjects[indexPath.row]
-        case .done:
-            selectedProject = doneProjects[indexPath.row]
-        }
-        
-        return selectedProject
+        return nil
     }
     
     func didSelectRow(indexPath: IndexPath, state: ProjectState) {
-        guard let selectedProject = retrieveSelectedData(indexPath: indexPath, state: state) else {
-            return
-        }
-        onCellSelected?(indexPath, selectedProject)
-    }
-    
-    func numberOfProjects(state: ProjectState) -> Int {
-        switch state {
-        case .todo:
-            return todoProjects.count
-        case .doing:
-            return doingProjects.count
-        case .done:
-            return doneProjects.count
-        }
-    }
-    
-    func fetchAll() {
-        projects = useCase.fetchAll()
     }
     
     func append(_ project: Project) {
         useCase.append(project)
-        fetchAll()
     }
     
     func update(_ project: Project, state: ProjectState?) {
         useCase.update(project, to: state)
-        fetchAll()
     }
     
     func delete(indexPath: IndexPath, state: ProjectState) {
-        guard let project = retrieveSelectedData(indexPath: indexPath, state: state) else {
-            return
-        }
-        useCase.delete(project)
-        fetchAll()
     }
     
     func changeState(from oldState: ProjectState, to newState: ProjectState, indexPath: IndexPath) {
-        guard let project = retrieveSelectedData(indexPath: indexPath, state: oldState) else {
-            return
-        }
-        self.update(project, state: newState)
     }
     
     func createEditDetailViewModel(indexPath: IndexPath, state: ProjectState) -> EditProjectDetailViewModel {
-        let project = retrieveSelectedData(indexPath: indexPath, state: state) ?? Project(id: UUID(), state: .todo, title: "", body: "", date: Date())
+        let project = Project(id: UUID(), state: .todo, title: "", body: "", date: Date())
         return EditProjectDetailViewModel(currentProject: project)
     }
     

--- a/ProjectManager/ProjectManager/ViewModel/ProjectListViewModel.swift
+++ b/ProjectManager/ProjectManager/ViewModel/ProjectListViewModel.swift
@@ -1,9 +1,14 @@
 import UIKit
 
-protocol ProjectListViewModelProtocol: UITableViewDataSource {
+protocol ProjectListViewModelProtocol {
     var onCellSelected: ((IndexPath, Project) -> Void)? { get set }
     var onUpdated: (() -> Void)? { get set }
     
+    var todoProjects: [Project] { get }
+    var doingProjects: [Project] { get }
+    var doneProjects: [Project] { get }
+    
+    func retrieveSelectedData(indexPath: IndexPath, state: ProjectState) -> Project?
     func didSelectRow(indexPath: IndexPath, state: ProjectState)
     func numberOfProjects(state: ProjectState) -> Int
     func fetchAll()
@@ -31,19 +36,19 @@ final class ProjectListViewModel: NSObject, ProjectListViewModelProtocol {
         }
     }
     
-    private var todoProjects: [Project] {
+    var todoProjects: [Project] {
         projects.filter { $0.state == .todo }
     }
     
-    private var doingProjects: [Project] {
+    var doingProjects: [Project] {
         projects.filter { $0.state == .doing }
     }
     
-    private var doneProjects: [Project] {
+    var doneProjects: [Project] {
         projects.filter { $0.state == .done }
     }
     
-    private func retrieveSelectedData(indexPath: IndexPath, state: ProjectState) -> Project? {
+    func retrieveSelectedData(indexPath: IndexPath, state: ProjectState) -> Project? {
         var selectedProject: Project?
         switch state {
         case .todo:
@@ -111,39 +116,5 @@ final class ProjectListViewModel: NSObject, ProjectListViewModelProtocol {
     
     func createAddDetailViewModel() -> AddProjectDetailViewModel {
         return AddProjectDetailViewModel()
-    }
-}
-
-extension ProjectListViewModel {
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        guard let state = (tableView as? ProjectListTableView)?.state else {
-            return .zero
-        }
-    
-        switch state {
-        case .todo:
-            return todoProjects.count
-        case .doing:
-            return doingProjects.count
-        case .done:
-            return doneProjects.count
-        }
-    }
-    
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let state = ((tableView as? ProjectListTableView)?.state),
-              let project = retrieveSelectedData(indexPath: indexPath, state: state),
-              let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date()) else {
-            return UITableViewCell()
-        }
-
-        let cell = tableView.dequeueReusableCell(withClass: ProjectListTableViewCell.self)
-        if project.date < yesterday {
-            cell.populateDataWithDate(title: project.title, body: project.body, date: project.date)
-        } else {
-            cell.populateData(title: project.title, body: project.body, date: project.date)
-        }
-
-        return cell
     }
 }

--- a/ProjectManager/ProjectManager/ViewModel/ProjectListViewModel.swift
+++ b/ProjectManager/ProjectManager/ViewModel/ProjectListViewModel.swift
@@ -44,7 +44,8 @@ final class ProjectListViewModel: ViewModelType {
         useCase.delete(project)
     }
     
-    func changeState(from oldState: ProjectState, to newState: ProjectState, indexPath: IndexPath) {
+    func changeState(from project: Project, to newState: ProjectState) {
+        useCase.update(project, to: newState)
     }
     
     func createEditDetailViewModel(with selectedProject: Project) -> EditProjectDetailViewModel {

--- a/ProjectManager/ProjectManager/ViewModel/ProjectListViewModel.swift
+++ b/ProjectManager/ProjectManager/ViewModel/ProjectListViewModel.swift
@@ -32,13 +32,6 @@ final class ProjectListViewModel: ViewModelType {
         self.useCase = useCase
     }
     
-    func retrieveSelectedData(indexPath: IndexPath, state: ProjectState) -> Project? {
-        return nil
-    }
-    
-    func didSelectRow(indexPath: IndexPath, state: ProjectState) {
-    }
-    
     func append(_ project: Project) {
         useCase.append(project)
     }
@@ -47,7 +40,8 @@ final class ProjectListViewModel: ViewModelType {
         useCase.update(project, to: state)
     }
     
-    func delete(indexPath: IndexPath, state: ProjectState) {
+    func delete(project: Project) {
+        useCase.delete(project)
     }
     
     func changeState(from oldState: ProjectState, to newState: ProjectState, indexPath: IndexPath) {

--- a/ProjectManager/ProjectManager/ViewModel/ProjectListViewModel.swift
+++ b/ProjectManager/ProjectManager/ViewModel/ProjectListViewModel.swift
@@ -3,7 +3,6 @@ import RxSwift
 
 final class ProjectListViewModel: ViewModelType {
     struct Input {
-
     }
     
     struct Output {
@@ -54,9 +53,8 @@ final class ProjectListViewModel: ViewModelType {
     func changeState(from oldState: ProjectState, to newState: ProjectState, indexPath: IndexPath) {
     }
     
-    func createEditDetailViewModel(indexPath: IndexPath, state: ProjectState) -> EditProjectDetailViewModel {
-        let project = Project(id: UUID(), state: .todo, title: "", body: "", date: Date())
-        return EditProjectDetailViewModel(currentProject: project)
+    func createEditDetailViewModel(with selectedProject: Project) -> EditProjectDetailViewModel {
+        return EditProjectDetailViewModel(usecase: useCase, currentProject: selectedProject)
     }
     
     func createAddDetailViewModel() -> AddProjectDetailViewModel {

--- a/ProjectManager/ProjectManager/ViewModel/ProjectListViewModel.swift
+++ b/ProjectManager/ProjectManager/ViewModel/ProjectListViewModel.swift
@@ -1,26 +1,18 @@
 import UIKit
 
-protocol ProjectListViewModelProtocol {
-    var onCellSelected: ((IndexPath, Project) -> Void)? { get set }
-    var onUpdated: (() -> Void)? { get set }
+final class ProjectListViewModel: ViewModelType {
+    final class Input {
+//        let doneButton
+    }
     
-    var todoProjects: [Project] { get }
-    var doingProjects: [Project] { get }
-    var doneProjects: [Project] { get }
+    final class Output {
+        
+    }
     
-    func retrieveSelectedData(indexPath: IndexPath, state: ProjectState) -> Project?
-    func didSelectRow(indexPath: IndexPath, state: ProjectState)
-    func numberOfProjects(state: ProjectState) -> Int
-    func fetchAll()
-    func append(_ project: Project)
-    func update(_ project: Project, state: ProjectState?)
-    func delete(indexPath: IndexPath, state: ProjectState)
-    func changeState(from oldState: ProjectState, to newState: ProjectState, indexPath: IndexPath)
-    func createEditDetailViewModel(indexPath: IndexPath, state: ProjectState) -> EditProjectDetailViewModel
-    func createAddDetailViewModel() -> AddProjectDetailViewModel
-}
-
-final class ProjectListViewModel: NSObject, ProjectListViewModelProtocol {
+    func transform(input: Input) -> Output {
+        return Output()
+    }
+    
     let useCase: ProjectUseCaseProtocol
     
     var onCellSelected: ((IndexPath, Project) -> Void)?
@@ -115,6 +107,6 @@ final class ProjectListViewModel: NSObject, ProjectListViewModelProtocol {
     }
     
     func createAddDetailViewModel() -> AddProjectDetailViewModel {
-        return AddProjectDetailViewModel()
+        return AddProjectDetailViewModel(useCase: useCase)
     }
 }

--- a/ProjectManager/ProjectManager/ViewModel/ViewModelType.swift
+++ b/ProjectManager/ProjectManager/ViewModel/ViewModelType.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+protocol ViewModelType {
+    associatedtype Input
+    associatedtype Output
+    
+    func transform(input: Input) -> Output
+}

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Uikit에선 UI Components와 Datasource를 바인딩할 때 delegate 패턴을 �
 
 이전 프로젝트에서 DropBox를 사용해보았는데 레퍼런스가 없어 문제 해결을 못하는 일이 변변치않게 발생하였는데, Realm, Firebase는 문제 발생시 해결에 도움이 되는 레퍼런스가 많다는 이유 하나만으로도 충분히 사용할 이유가 된다고 생각했습니다.
 
-## 🍎 사용한 기술 스택에 대한 고민
+## 🐈 사용한 기술 스택에 대한 고민
 
 ### 1. 하위 버전 호환성에는 문제가 없는가?
 
 |Firebase|Realm|
 |:--:|:--:|
-|![Untitled](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/d3a7b9bc-3760-4f24-a35d-df0139e6b8f5/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20220301%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220301T082931Z&X-Amz-Expires=86400&X-Amz-Signature=408c193fefe3b153b05b9196ddaf39f4362d08d69d1467050ce3f3c61d9eba82&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22Untitled.png%22&x-id=GetObject)|![Untitled](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/1b1cdd84-2320-451b-8058-6f3b137247c0/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20220301%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220301T083002Z&X-Amz-Expires=86400&X-Amz-Signature=36e306b636db0bc3c4a65637ad317b3af9726dfd30641974466c7b9619a42b9a&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22Untitled.png%22&x-id=GetObject)|
+|<img width="352" alt="image" src="https://user-images.githubusercontent.com/70251136/158818812-8921c3c1-d11c-4773-88eb-fa264ad3fd5a.png">|<img width="276" alt="image" src="https://user-images.githubusercontent.com/70251136/158818870-b553e6c9-6421-42e4-82e7-5d34ec275616.png">|
 
 Firebase는 iOS 10, Realm은 iOS 9부터 지원하기 때문에 저희 프로젝트 최소 타깃인 iOS 13을 커버하기에 무리가 없다고 판단하였습니다.
 
@@ -66,7 +66,7 @@ Firebase와 Realm이 지원하는 의존성 관리도구에는 아래 세가지�
 - 로컬에 저장 - Realm
 - 서버에 저장 및 동기화 - Firebase
 
-## 🍎 객체지향 프로그래밍 vs 함수형프로그래밍
+## 🐈 객체지향 프로그래밍 vs 함수형프로그래밍
 
 객체지향은 객체 안에 상태를 저장하고 상태를 조정하기 위해 다양한 기능을 사용하는 반면에
 
@@ -127,7 +127,7 @@ console.log( add(10 , 5) );    // 출력값 15
 
 인풋값으로 a와 b를 받는데 함수 안에 변수 c가 존재한다면 c의 값에 따라 아웃풋이 달라지기 때문에 순수함수가 아닙니다.
 
-## 🍎 디자인 패턴에 대한 고민
+## 🐈 디자인 패턴에 대한 고민
 
 ### MVVM vs MVC
 
@@ -191,7 +191,7 @@ Model + View + ViewModel로 이루어진 패턴으로 각각 다음과 같은 �
 
 <br>
 
-## 🍎 Rest API는 무엇이고, 왜 중요한가?
+## 🐈 Rest API는 무엇이고, 왜 중요한가?
 
 ### **Rest란?** 
 
@@ -205,7 +205,7 @@ Rest를 기반으로 제작된 API입니다.
 
 <br>
 
-## 🍎 알아두면 좋을 것들
+## 🐈 알아두면 좋을 것들
 
 - 뷰는 테스트를 왜 하기 어렵고 뷰모델은 왜 테스트하기 쉬울까?
 - 뷰모델은 프로퍼티로 모델을 가지고 있습니다.
@@ -223,7 +223,7 @@ Rest를 기반으로 제작된 API입니다.
 
 ![Simulator Screen Recording - iPad (9th generation) - 2022-03-07 at 22 31 45](https://user-images.githubusercontent.com/70251136/157047799-add8dfc1-8e0f-4fe9-ba23-e3119d0797cf.gif)
 
-## 🍎 Lazy 키워드 사용에 대한 고민
+## 🐈 Lazy 키워드 사용에 대한 고민
 
 ```swift
 private lazy var entireStackView: UIStackView = {
@@ -279,7 +279,7 @@ private let entireStackView: UIStackView = {
 
 참고 링크: [https://www.avanderlee.com/swift/lazy-var-property/](https://www.avanderlee.com/swift/lazy-var-property/)
 
-## 🍎 View 부분 문제 해결
+## 🐈 View 부분 문제 해결
 
 ### sectionHeaderTopPadding
 
@@ -366,7 +366,7 @@ let spacerView: UIView = {
 
 레이블의 텍스트를 길게 적어도 숫자 레이블이 안깨지는 모습을 볼 수 있다.
 
-## 🍎 View 부분 추가 구현 사항
+## 🐈 View 부분 추가 구현 사항
 
 ### label 동그랗게 만드는 방법
 
@@ -404,7 +404,7 @@ extension UIView {
 textField.borderStyle = .roundedRect
 ```
 
-## 🍎 오토레이아웃 알게된 부분
+## 🐈 오토레이아웃 알게된 부분
 
 ### **Constraint Priorites**
 
@@ -419,3 +419,309 @@ textField.borderStyle = .roundedRect
 
 참고 링크: 
 [https://stackoverflow.com/questions/36924093/what-are-the-default-auto-layout-content-hugging-and-content-compression-resista](https://stackoverflow.com/questions/36924093/what-are-the-default-auto-layout-content-hugging-and-content-compression-resista)
+
+# STEP 2-2
+
+STEP 2-2에서는 UIKit를 사용하여 MVVM 구조로 구현하였습니다.
+
+클로저와 데이터 바인딩을 사용하여 데이터 전달을 구현했고, 다음 스텝에서는 RxSwift로 프로젝트를 리팩토링할 예정입니다.  
+
+# 🐈 앱의 주요 기능
+
+- CRUD
+    - 서버에서 저장된 데이터 불러오기 (구현 예정)
+    - 네비게이션바의 + 버튼 터치시 새로운 할일 추가
+    - 셀 터치시 상세화면으로 이동하여 할일 내용 수정
+    - 셀 왼쪽으로 스와이프시 삭제
+- 셀 길게 터치시 팝오버 메뉴 표시하여 할일을 다른 테이블뷰로 이동
+- 날짜를 사용자의 지역, 언어에 맞게 표현
+- Date Picker을 이용한 날짜 입력
+
+# 🐈 MVVM + Clean Architecture 구조
+
+![image](https://user-images.githubusercontent.com/70251136/158818142-da74dc3e-1981-4268-8b2a-e8a44e44b18f.png)
+
+![image](https://user-images.githubusercontent.com/70251136/158818189-7d3a496e-0c84-4817-951f-bcf8cf31d5a7.png)
+
+## 🐈 Model
+
+- Project가 가진 정보를 가지고 있는 모델입니다.
+- 테스트를 위해 Equatable을 채택해주었습니다.
+
+## 🐈 View
+
+- ListVC는 테이블뷰를 가지고 있는 VC입니다.
+- AddDetailVC, EditDetailVC는 DetailVC를 상속받고 있습니다. DetailVC를 둔 이유는 두 VC의 공통된 부분을 하나로 관리하기 위해서입니다.
+- ~~하나의 ViewModel을 사용하기 위해 ListVC, AddDetailVC, EditDetailVC에 생성자 주입을 해주었습니다.~~
+    
+    → 각 VC는 하나의 ViewModel만 가져야 한다는 피드백을 받고 ListVC, AddDetailVC, EditDetailVC가 각각 ListVM, AddDetailVM, EditDetailVM을 가지도록 수정해주었습니다.
+    
+## 🐈 ViewModel
+
+### ListViewModel
+
+- project 배열을 가지고 있습니다.
+- UseCase를 가지고 있으며 UseCase가 Repository를 통해 가져온 데이터를 View에 보여줄 데이터로 변환해주는 역할을 합니다.
+- 바인딩을 위해 클로저를 가지고 있으며 View에서 요청이 들어오면 서버단의 데이터까지 업데이트한 후 클로저에 정의한 작업을 수행하게 하였습니다.
+- tableViewDataSource를 채택하고 있습니다. 가지고 있는 데이터를 통해 tableView에 데이터를 뿌려줍니다.
+- AddDetailViewModel, EditDetailViewModel을 생성하는 메서드를 가지고 있습니다.
+
+### EditDetailViewModel
+
+- 수정할 project만 가지고 있습니다.
+- 바인딩을 위한 클로저를 가지며 Done버튼 터치시 클로저에 정의한 데이터를 업데이트하는 작업을 수행합니다.
+- UseCase를 가지고 있지 않으며 서버에 업데이트할때는 ListViewModel을 거쳐서 전달됩니다.
+
+### AddDetailViewModel
+
+- 바인딩을 위한 클로저를 가지며 Done버튼 터치시 클로저에 정의한 데이터를 추가(업데이트)하는 작업을 수행합니다.
+- UseCase를 가지고 있지 않으며 서버에 업데이트할때는 ListViewModel을 거쳐서 전달됩니다.
+
+## 🐈 UseCase
+
+- 비즈니스 로직이 구현되어 있는 곳입니다.
+- Repository를 가지고 있으며 viewModel과 연관이 없어 테스트하기 용이하고, 실제로 해당 UseCase 테스트를 진행하였습니다.
+
+## 🐈 Repository
+
+- Repository는 Key로 ID, Value로 Project타입을 가진 딕셔너리를 가지고 있습니다. (Entity)
+- Local, Remote 저장소에 특정 작업을 요청하는 곳이며, 현재는 변수에 저장하는 식으로 구현이 되어있습니다. (구현 예정)
+- 해당 클래스를 추상화하고 Mock을 만들어 변수에 가짜 데이터를 넘겨주고, 비즈니스 로직을 테스트할 수 있도록 하였습니다. (네트워킹을 하지 않는 테스트)
+
+## 🐈 Unidirectional Data Flow
+
+크게 세가지의 데이터 전달 로직을 구현하였습니다.
+
+1. 테이블 뷰 셀 터치시 상세화면 모달로 이동 
+    - ListVC에서 테이블 뷰 셀 클릭시 DetailVC로 데이터 전달: 클로저 활용
+        - ListVC에서 ListVM이 가진 onCellSelected 클로저 정의
+        - 셀이 선택되면 호출되는 didSelectRowAt 메서드에서 파라미터로 선택된 인덱스와, 테이블뷰를 받는 viewModel의 didselectRow메서드를 호출
+        - didSelectRow 메서드에서는 tableView가 가진 State를 통해 분기 처리, 이후 분기하여 나온 데이터 집합을 파라미터로 받은 인덱스를 통해 특정 데이터를 꺼내주고, 해당 데이터와 인덱스를 onCellSelected의 파라미터로 넣어준 뒤 호출
+        - 호출시 이전에 정의해놓은 작업(DetailVC Present)이 실행
+        
+        <코드>
+        
+        - ViewModel
+        
+        ```swift
+        var onCellSelected: ((Int, Project) -> Void)? // 선언부
+        
+        private func retrieveSelectedData(indexPath: IndexPath, state: ProjectState) -> Project? {
+            var selectedProject: Project?
+            switch state {
+            case .todo:
+                selectedProject = todoProjects[indexPath.row]
+            case .doing:
+                selectedProject = doingProjects[indexPath.row]
+            case .done:
+                selectedProject = doneProjects[indexPath.row]
+            }
+            
+            return selectedProject
+        }
+        
+        func didSelectRow(index: IndexPath, tableView: UITableView) {
+            guard let selectedProject = retrieveSelectedData(index: index, tableView: tableView) else {
+                return
+            }
+            onCellSelected?(indexPath, selectedProject) //실행부
+        }
+        ```
+        
+        - ListVC
+        
+        configureBind 메서드에서 셀이 선택될때 EditVC에 선택된 모델을 전달하며 화면을 present하는 로직 정의 
+        
+        ```swift
+        // 정의부
+        func configureBind() {
+            viewModel.tableViews = tableViews
+            viewModel.fetchAll()
+            
+            viewModel?.onCellSelected = { [weak self] indexPath, project in
+                guard let self = self, let viewModel = self.viewModel else {
+                    return
+                }
+                let editProjectDetailViewModel = viewModel.createEditDetailViewModel(indexPath: indexPath, state: project.state)
+                let editViewController = EditProjectDetailViewController(viewModel: editProjectDetailViewModel, delegate: self)
+                let destinationViewController = UINavigationController(rootViewController: editViewController)
+                destinationViewController.modalPresentationStyle = .formSheet
+                self.present(destinationViewController, animated: true, completion: nil)
+            }
+            
+            viewModel.onUpdated = {
+                self.tableViews.forEach {
+                    $0.reloadData()
+                }
+            }
+        }
+        
+        // didSelectRowAt
+        func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+            viewModel.didSelectRow(index: indexPath, tableView: tableView)
+        }
+        ```
+        
+2. 상세화면에서 수정 완료시 서버에 업데이트
+3. 상세화면이 dismiss되면 서버에서 데이터를 다시 가져와서 테이블 뷰에 데이터 업데이트
+    - EditDetailVC에서 Done 버튼 클릭시 ListVC를 업데이트: 클로저 활용
+        - DetailViewController에서 Project를 수정한 후 Done이 눌리면 뷰가 dismiss되며 EditDetailViewModel에 주입된 Project를 수정했습니다.
+        
+        ```swift
+        self.dismiss(animated: true) {
+            self.updateListView()
+        }
+        
+        private func updateListView() {
+            guard let currentProject = viewModel?.currentProject else {
+                return
+            }
+            let updatedProject = self.updatedViewData(with: currentProject)
+            viewModel?.didTapDoneButton(updatedProject)
+        }
+        
+        func updatedViewData(with oldProject: Project) -> Project {
+            return Project(
+                id: oldProject.id,
+                state: oldProject.state,
+                title: projectDetailView.titleTextField.text ?? "",
+                body: projectDetailView.bodyTextView.text ?? "",
+                date: projectDetailView.datePicker.date)
+        }
+        ```
+        
+        - 수정된 Project를 EditDetailViewModel의 didTapDoneButton 메서드에 넣어준 뒤 해당Project를 이용해 클로저 호출했습니다.
+        
+        ```swift
+        func didTapDoneButton(_ project: Project) { 
+            onUpdated?(project) // 클로저 호출부
+        }
+        
+        viewModel?.onUpdated = { project in // 클로저 구현부
+            self.delegate?.didUpdateProject(project)
+        }
+        ```
+        
+        - delegate 패턴을 활용하여 ListViewController의 delegate 메서드 호출했습니다.
+        
+        ```swift
+        func didUpdateProject(_ project: Project) {
+            viewModel?.update(project, state: nil)
+        }
+        ```
+        
+        - ListViewModel이 가진 모델 업데이트시 서버의 데이터까지 업데이트 후 refatch 됩니다.
+        
+
+AddDetailVC, EditDetailVC 에서 할일 추가나 수정이 될때 ListVC에 바로 데이터를 전달하는 것이 아니라
+
+ViewModel → UseCase → Repository → Server 에 업데이트하고 
+
+ListVC는 Server에 업데이트된 정보를 다시 가져와서 뷰에 보여주는 방식으로 구조를 설계했습니다. 
+
+## 🐈 의존성 역전
+
+- repository, useCase, viewModel 의존성 주입 SceneDelegate에서 처리
+- viewModel에게 tableViews를 주입해주는 작업은 ListVC에서 처리
+- ListVC에서 ListVC가 가진 ListVM을 통해 AddDetailVC, EditDetailVC에 각각의 viewModel을 주입해주는 작업 처리
+
+# 🐈 고민했던 부분
+
+### View에서 화면의 데이터를 반환하는 메서드를 정의하여도 괜찮을까?
+
+크게 문제는 없어 보이지만, 뷰의 역할은 화면을 그리는 역할이기때문에 화면 뷰 요소에 담긴 데이터를 모델 형식으로 반환하는 메서드를 ProjectDetailView → ProjectDetailViewController로 위치 이동
+
+```swift
+func createViewData() -> Project {
+    return Project(
+        id: UUID(),
+        state: .todo,
+        title: projectDetailView.titleTextField.text ?? "",
+        body: projectDetailView.bodyTextView.text ?? "",
+        date: projectDetailView.datePicker.date)
+}
+
+func updatedViewData(with oldProject: Project) -> Project {
+    return Project(
+        id: oldProject.id,
+        state: oldProject.state,
+        title: projectDetailView.titleTextField.text ?? "",
+        body: projectDetailView.bodyTextView.text ?? "",
+        date: projectDetailView.datePicker.date)
+}
+```
+
+### ViewModel에 뷰 요소가 있어도 될까?
+
+기존에는 UITableViewDataSource를 채택하고있는 viewModel이 특정 tableView를 업데이트하거나, 삭제하는 작업을 할 때 어떤 tableView에서 업데이트, 삭제하는지 분기처리를 해줘야하기때문에 viewModel에 tableView를 프로퍼티 주입을 해주었습니다.
+
+그러나 뷰모델이 최대한 뷰요소를 알지 못하게 하는 것이 나은 방향이라고 생각하여 tableView의 State만 주입해주는 방식으로 변경했습니다.  
+
+```swift
+class ProjectListTableView: UITableView {
+    var state: State
+
+    init(state: State) {
+        self.state = state
+        super.init(frame: .zero, style: .plain)
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+```
+
+### required init fatal error 제거
+
+`fatalError`가 발생하는 코드블럭이 당장 실행될 일이 없어도, 향후 코드를 쌓다보면 `fatalError`가 많아질 수 있고, 그로 인해 큰 파장을 갖고올 수 있기때문에 절대 옳지않다라고 판단
+
+그래서 이를 해결하기위해 이니셜라이저로 받는 프로퍼티를 옵셔널로 둬 required init에서 다시 초기화해야되는 상황을 막고, `fatalError`를 `super.init(coder: coder)` 으로 변경
+
+```swift
+class ProjectListViewController: UIViewController {
+    private var viewModel: ProjectViewModelProtocol
+
+    init(viewModel: ProjectViewModelProtocol) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+		required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+```
+
+```swift
+class ProjectListViewController: UIViewController {
+    private var viewModel: ProjectViewModelProtocol?
+
+    init(viewModel: ProjectViewModelProtocol) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}
+```
+
+### ViewModel이 여러 ViewController에게 공유되어도 될까?
+
+원래는 할일 목록을 가진 ListVC와 할일 상세화면을 가진 AddVC, EditVC는 모두 하나의 뷰모델을 공유하고 있도록 구현하였습니다. 그 이유는 세 뷰컨 모두 보여주는 데이터가 크게 다르지 않다고 생각해서였습니다.
+
+그러나, 뷰모델이 공유되면 안되는 이유로는 예상치 못한 부수효과가 생길수도 있고, 나중에 코드를 보는 사람이 뷰모델이 어느 뷰컨에 해당하는지 혼란이 올 수도 있다고 생각했습니다.
+
+각 VC는 하나의 ViewModel만 가져야 한다는 피드백을 받고 ListVC, AddDetailVC, EditDetailVC가 각각 ListVM, AddDetailVM, EditDetailVM을 가지도록 수정해주었습니다.
+
+# 우리의 고민 흔적들...🐈 🐈 🐈 🐈 
+
+![image](https://user-images.githubusercontent.com/70251136/158818261-3bf0c1c0-8cf2-4a35-ace3-5d91b1a07afa.png)
+
+![image](https://user-images.githubusercontent.com/70251136/158818301-b5c3d1bb-4e1f-4f6a-aaa0-4fd4b9725a29.png)
+
+![image](https://user-images.githubusercontent.com/70251136/158818339-24f1cb6d-6ff6-474b-bafe-a1dd53cc5370.png)
+


### PR DESCRIPTION

안녕하세요 제이슨 [@ehgud0670](https://github.com/ehgud0670)

지성, 제인입니다
어느덧 마지막 PR이네요,, 그동안 정말 감사했습니다.
디스코드로 여러번 대화 나누며 많은 도움 받은 것 같습니다..😊
이번에는 RxCocoa, RxSwift를 적용하여 바인딩을 구현해보았습니다

늦었지만 잘 부탁드립니다...😁

# 구조

리팩토링 전에는 List뷰모델만 UseCase를 알고, Add와 Edit은 List뷰모델을 통해서 useCase와 소통하는 구조였는데

이제는 각각의 뷰모델이 모두 동일한 useCase를 알고, 직접 소통하는 구조로 수정하였습니다.

<img width="811" alt="image" src="https://user-images.githubusercontent.com/60725934/160243417-152f2364-18f4-4d84-a14b-f1dbb9980d1f.png">


## View가 가진 State 제거

리뷰 주신대로 View가 모델의 상태값을 가지는 것이 옳지 않은 것 같아 State를 제거하였고, CRUD 시 다루는 Project의 State를 확인하도록 로직을 변경하였습니다.

## UITableViewDataSource, UITableViewDelegate 제거

### UITableViewDataSource

1. Repository가 가진 Data를 BehaviorRelay<[UUID: Project]>로 구현 
2. UseCase 는 Reposiotry의 Data를 받아서 Observable<[Project]>로 리턴 
3. ListViewModel은 UseCase의 Data를 filter하여 세가지 타입의 Observable을 가짐 
4. ListViewController는 각 Observable을 세가지 테이블뷰에 바인딩하여 데이터소스로 활용

→ 이렇게 Repo의 데이터를 뷰컨에 바인딩하여 셀 추가, 삭제, 이동이 이루어져서 Repo의 데이터가 변하면 별도의 알림(?) 없이도 테이블뷰가 업데이트되도록 구현했습니다.

이런 방식으로 구현하면 제 생각으로는 데이터가 변경되었다는 알림을 받지 않아도 자동으로 UI가 업데이트되어 굉장히 편한 것 같은데... **어떤식으로 구현하는것이 더 좋은 방법인지 궁금합니다**... 😅

### UITableViewDelegate

**RxCocoa 로 뷰 요소 바인딩**

- navigationBarButton
- tableView 셀 선택, 셀 삭제
- longPressGestureRecognizer

# 아쉬운 부분

## 테이블 뷰 셀 선택에 대한 처리를 뷰컨이 하고 있는 부분

```swift
tableViews.forEach {
    $0.rx.modelSelected(Project.self)
        .subscribe(onNext: { [weak self] project in
            guard let viewModel = self?.viewModel else {
                return
            }
            let editProjectDetailViewModel = viewModel.createEditDetailViewModel(with: project)
            let viewController = EditProjectDetailViewController(viewModel: editProjectDetailViewModel)
            let destinationViewController = UINavigationController(rootViewController: viewController)
            
            destinationViewController.modalPresentationStyle = .formSheet
            self?.present(destinationViewController, animated: true, completion: nil)
        }).disposed(by: disposeBag)
}
```

테이블뷰 셀 선택을 observable로 변환하여 input으로 ViewModel에 넘겨서 

ViewModel이 이벤트에 대한 처리를 하고 Navigator Pattern이나 Coordinator Pattern을 적용하여 화면전환 로직(ex) EditDetailView 띄우기)을 분리해내면 좋았을텐데... 시간 관계상 진행하지 못했습니다. 

또한 delegate Pattern을 적용해 ViewModel의 Delegate를  VC로 두어 진행할 수도 있었겠지만, 결과적으로 VC가 작업을 하는 것은 같기 때문에 해당 방법으론 진행하지 않았습니다.

# 궁금한 점

### ViewModel들의 Input, Output을 보시면 내부가 비어있는 곳이 있습니다.

```swift
final class ProjectListViewModel: ViewModelType {
    struct Input {
    }
    
    struct Output {
        let todoProjects: Observable<[Project]>
        let doingProjects: Observable<[Project]>
        let doneProjects: Observable<[Project]>
    }
    
    func transform(input: Input) -> Output {
        let todoProjects = useCase.bindProjects()
            .map { $0.filter { $0.state == .todo }}
        
        let doingProjects = useCase.bindProjects()
            .map { $0.filter { $0.state == .doing }}
        
        let doneProjects = useCase.bindProjects()
            .map { $0.filter { $0.state == .done }}
        
        return Output(todoProjects: todoProjects,
                      doingProjects: doingProjects,
                      doneProjects: doneProjects)
    }
}
```

이유는 celldidtap, diddelete 같은 Observable을 viewModel의 input으로 넣어주려했으나 그럼 project 배열을 가진 Observable 배열을 넣어줘야 했습니다. `[Observable<[Project]]`

하지만 Observable 배열은 옳지 않은 것 같아 추가해주지 않았는데.. 저희의 생각과는 다르게 Observable 배열을 만들어 Input에 넣어주는 것이 괜찮은 방법인지 궁금합니다.

그렇게 생각한 이유는 구글링중 보통 위같은 방법은 옳지않다.. 라고 보았습니다.

감사합니다☺️