### PR TITLE
프로젝트 관리 앱 [STEP 2-3] Lingo

### DIFF
--- a/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
+++ b/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		B032CDA32873BFB20087383E /* CardListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B032CDA22873BFB20087383E /* CardListTableViewCell.swift */; };
 		B032CDA62873DAC00087383E /* CardListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B032CDA52873DAC00087383E /* CardListHeaderView.swift */; };
 		B032CDA82873F3610087383E /* AppAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = B032CDA72873F3610087383E /* AppAppearance.swift */; };
+		B0DA23EF287AD66700576D5E /* UITableView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DA23EE287AD66700576D5E /* UITableView+Extension.swift */; };
 		B0EF5B18287522E000A503A9 /* CardSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0EF5B17287522E000A503A9 /* CardSectionView.swift */; };
 		C7431F0625F51E1D0094C4CF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7431F0525F51E1D0094C4CF /* AppDelegate.swift */; };
 		C7431F0825F51E1D0094C4CF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7431F0725F51E1D0094C4CF /* SceneDelegate.swift */; };
@@ -38,6 +39,7 @@
 		B032CDA22873BFB20087383E /* CardListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardListTableViewCell.swift; sourceTree = "<group>"; };
 		B032CDA52873DAC00087383E /* CardListHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardListHeaderView.swift; sourceTree = "<group>"; };
 		B032CDA72873F3610087383E /* AppAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAppearance.swift; sourceTree = "<group>"; };
+		B0DA23EE287AD66700576D5E /* UITableView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Extension.swift"; sourceTree = "<group>"; };
 		B0EF5B17287522E000A503A9 /* CardSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardSectionView.swift; sourceTree = "<group>"; };
 		C7431F0225F51E1D0094C4CF /* ProjectManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ProjectManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7431F0525F51E1D0094C4CF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -139,6 +141,22 @@
 			path = MainScene;
 			sourceTree = "<group>";
 		};
+		B0DA23EC287AD62700576D5E /* Util */ = {
+			isa = PBXGroup;
+			children = (
+				B0DA23ED287AD63600576D5E /* Extension */,
+			);
+			path = Util;
+			sourceTree = "<group>";
+		};
+		B0DA23ED287AD63600576D5E /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				B0DA23EE287AD66700576D5E /* UITableView+Extension.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		C7431EF925F51E1D0094C4CF = {
 			isa = PBXGroup;
 			children = (
@@ -161,6 +179,7 @@
 				B001066F287298D30080ACC7 /* Application */,
 				B01DCDC728732AC000AFF91A /* Model */,
 				B01DCDD0287347DE00AFF91A /* Scene */,
+				B0DA23EC287AD62700576D5E /* Util */,
 				B0010670287298DC0080ACC7 /* Resource */,
 			);
 			path = ProjectManager;
@@ -254,6 +273,7 @@
 				B009119828781F44007074E5 /* CardListViewModelItem.swift in Sources */,
 				B0EF5B18287522E000A503A9 /* CardSectionView.swift in Sources */,
 				C7431F0825F51E1D0094C4CF /* SceneDelegate.swift in Sources */,
+				B0DA23EF287AD66700576D5E /* UITableView+Extension.swift in Sources */,
 				B01748BF287744DF00EE15B0 /* CardEditView.swift in Sources */,
 				B032CDA62873DAC00087383E /* CardListHeaderView.swift in Sources */,
 				B01DCDD32873485000AFF91A /* CardListViewModel.swift in Sources */,

--- a/ProjectManager/ProjectManager/Model/Card.swift
+++ b/ProjectManager/ProjectManager/Model/Card.swift
@@ -19,6 +19,17 @@ enum CardType: CustomStringConvertible {
     case .done: return "DONE"
     }
   }
+  
+  var moveToMenuTitle: String {
+    switch self {
+    case .todo:
+      return "MOVE TO TODO"
+    case .doing:
+      return "MOVE TO DOING"
+    case .done:
+      return "MOVE TO DONE"
+    }
+  }
 }
 
 struct Card: Equatable {

--- a/ProjectManager/ProjectManager/Scene/MainScene/ViewController/CardAdditionViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/MainScene/ViewController/CardAdditionViewController.swift
@@ -18,9 +18,9 @@ final class CardAdditionViewController: UIViewController {
   
   private let cardEditView = CardEditView()
   private let disposeBag = DisposeBag()
-  private let viewModel: CardListViewModel
+  private let viewModel: CardListViewModelable
   
-  init(viewModel: CardListViewModel) {
+  init(viewModel: CardListViewModelable) {
     self.viewModel = viewModel
     super.init(nibName: nil, bundle: nil)
     configureSubViews()

--- a/ProjectManager/ProjectManager/Scene/MainScene/ViewController/CardDetailViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/MainScene/ViewController/CardDetailViewController.swift
@@ -21,10 +21,10 @@ final class CardDetailViewController: UIViewController {
   private var isEditable = false
   
   private let disposeBag = DisposeBag()
-  private let viewModel: CardListViewModel
+  private let viewModel: CardListViewModelable
   private let card: Card
   
-  init(viewModel: CardListViewModel, card: Card) {
+  init(viewModel: CardListViewModelable, card: Card) {
     self.viewModel = viewModel
     self.card = card
     super.init(nibName: nil, bundle: nil)

--- a/ProjectManager/ProjectManager/Scene/MainScene/ViewController/CardListViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/MainScene/ViewController/CardListViewController.swift
@@ -120,10 +120,21 @@ final class CardListViewController: UIViewController {
   }
   
   private func bindSectionsItemSelected() {
-    Observable.zip(
-      todoSectionView.tableView.rx.itemSelected,
-      todoSectionView.tableView.rx.modelSelected(Card.self)
+    Observable.of(
+      Observable.zip(
+        todoSectionView.tableView.rx.itemSelected,
+        todoSectionView.tableView.rx.modelSelected(Card.self)
+      ),
+      Observable.zip(
+        doingSectionView.tableView.rx.itemSelected,
+        doingSectionView.tableView.rx.modelSelected(Card.self)
+      ),
+      Observable.zip(
+        doneSectionView.tableView.rx.itemSelected,
+        doneSectionView.tableView.rx.modelSelected(Card.self)
+      )
     )
+    .merge()
     .bind(onNext: { [weak self] indexPath, card in
       guard let self = self else { return }
       self.todoSectionView.tableView.deselectRow(at: indexPath, animated: true)
@@ -132,58 +143,16 @@ final class CardListViewController: UIViewController {
       self.present(cardDetailViewController, animated: true)
     })
     .disposed(by: disposeBag)
-    
-    Observable.zip(
-      doingSectionView.tableView.rx.itemSelected,
-      doingSectionView.tableView.rx.modelSelected(Card.self)
-    )
-    .bind(onNext: { [weak self] indexPath, card in
-      guard let self = self else { return }
-      self.doingSectionView.tableView.deselectRow(at: indexPath, animated: true)
-      let cardDetailViewController = CardDetailViewController(viewModel: self.viewModel, card: card)
-      cardDetailViewController.modalPresentationStyle = .formSheet
-      self.present(cardDetailViewController, animated: true)
-    })
-    .disposed(by: disposeBag)
-    
-    Observable.zip(
-      doneSectionView.tableView.rx.itemSelected,
-      doneSectionView.tableView.rx.modelSelected(Card.self)
-    )
-    .bind(onNext: { [weak self] indexPath, card in
-      guard let self = self else { return }
-      self.doneSectionView.tableView.deselectRow(at: indexPath, animated: true)
-      let cardDetailViewController = CardDetailViewController(viewModel: self.viewModel, card: card)
-      cardDetailViewController.modalPresentationStyle = .formSheet
-      self.present(cardDetailViewController, animated: true)
-    })
-    .disposed(by: disposeBag)
   }
   
   private func bindSectionsItemDeleted() {
-    Observable.zip(
-      todoSectionView.tableView.rx.itemDeleted,
-      todoSectionView.tableView.rx.modelDeleted(Card.self)
-    )
-    .bind(onNext: { [weak self] indexPath, card in
-      self?.viewModel.deleteSelectedCard(card)
-    })
-    .disposed(by: disposeBag)
-    
-    Observable.zip(
-      doingSectionView.tableView.rx.itemDeleted,
-      doingSectionView.tableView.rx.modelDeleted(Card.self)
-    )
-    .bind(onNext: { [weak self] indexPath, card in
-      self?.viewModel.deleteSelectedCard(card)
-    })
-    .disposed(by: disposeBag)
-    
-    Observable.zip(
-      doneSectionView.tableView.rx.itemDeleted,
+    Observable.of(
+      todoSectionView.tableView.rx.modelDeleted(Card.self),
+      doingSectionView.tableView.rx.modelDeleted(Card.self),
       doneSectionView.tableView.rx.modelDeleted(Card.self)
     )
-    .bind(onNext: { [weak self] indexPath, card in
+    .merge()
+    .bind(onNext: { [weak self] card in
       self?.viewModel.deleteSelectedCard(card)
     })
     .disposed(by: disposeBag)

--- a/ProjectManager/ProjectManager/Scene/MainScene/ViewController/CardListViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/MainScene/ViewController/CardListViewController.swift
@@ -166,8 +166,7 @@ final class CardListViewController: UIViewController {
       todoSectionView.tableView.rx.modelDeleted(Card.self)
     )
     .bind(onNext: { [weak self] indexPath, card in
-      guard let self = self else { return }
-      self.viewModel.deleteSelectedCard(card)
+      self?.viewModel.deleteSelectedCard(card)
     })
     .disposed(by: disposeBag)
     
@@ -176,8 +175,7 @@ final class CardListViewController: UIViewController {
       doingSectionView.tableView.rx.modelDeleted(Card.self)
     )
     .bind(onNext: { [weak self] indexPath, card in
-      guard let self = self else { return }
-      self.viewModel.deleteSelectedCard(card)
+      self?.viewModel.deleteSelectedCard(card)
     })
     .disposed(by: disposeBag)
     
@@ -186,8 +184,7 @@ final class CardListViewController: UIViewController {
       doneSectionView.tableView.rx.modelDeleted(Card.self)
     )
     .bind(onNext: { [weak self] indexPath, card in
-      guard let self = self else { return }
-      self.viewModel.deleteSelectedCard(card)
+      self?.viewModel.deleteSelectedCard(card)
     })
     .disposed(by: disposeBag)
   }

--- a/ProjectManager/ProjectManager/Scene/MainScene/ViewController/CardListViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/MainScene/ViewController/CardListViewController.swift
@@ -58,6 +58,7 @@ final class CardListViewController: UIViewController {
     bindSectionsItems()
     bindSectionsItemSelected()
     bindSectionsItemDeleted()
+    bindSectionsLongPressed()
     
     cardAdditionButton.rx.tap
       .bind(onNext: { [weak self] in
@@ -189,6 +190,32 @@ final class CardListViewController: UIViewController {
       self.viewModel.deleteSelectedCard(card)
     })
     .disposed(by: disposeBag)
+  }
+  
+  private func bindSectionsLongPressed() {
+    todoSectionView.tableView.rx.modelLongPressed(Card.self)
+      .withUnretained(self)
+      .flatMap { wself, item in wself.showPopover(cell: item.0, card: item.1) }
+      .bind(onNext: { [weak self] card, cardType in
+        self?.viewModel.moveToOtherSection(card, cardType: cardType)
+      })
+      .disposed(by: disposeBag)
+    
+    doingSectionView.tableView.rx.modelLongPressed(Card.self)
+      .withUnretained(self)
+      .flatMap { wself, item in wself.showPopover(cell: item.0, card: item.1) }
+      .bind(onNext: { [weak self] card, cardType in
+        self?.viewModel.moveToOtherSection(card, cardType: cardType)
+      })
+      .disposed(by: disposeBag)
+    
+    doneSectionView.tableView.rx.modelLongPressed(Card.self)
+      .withUnretained(self)
+      .flatMap { wself, item in wself.showPopover(cell: item.0, card: item.1) }
+      .bind(onNext: { [weak self] card, cardType in
+        self?.viewModel.moveToOtherSection(card, cardType: cardType)
+      })
+      .disposed(by: disposeBag)
   }
 }
 

--- a/ProjectManager/ProjectManager/Scene/MainScene/ViewController/CardListViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/MainScene/ViewController/CardListViewController.swift
@@ -33,9 +33,9 @@ final class CardListViewController: UIViewController {
   }
   
   private let disposeBag = DisposeBag()
-  private let viewModel: CardListViewModel
+  private let viewModel: CardListViewModelable
   
-  init(viewModel: CardListViewModel) {
+  init(viewModel: CardListViewModelable) {
     self.viewModel = viewModel
     super.init(nibName: nil, bundle: nil)
     configureSubViews()

--- a/ProjectManager/ProjectManager/Scene/MainScene/ViewController/CardListViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/MainScene/ViewController/CardListViewController.swift
@@ -197,7 +197,7 @@ final class CardListViewController: UIViewController {
       .withUnretained(self)
       .flatMap { wself, item in wself.showPopover(cell: item.0, card: item.1) }
       .bind(onNext: { [weak self] card, cardType in
-        self?.viewModel.moveToOtherSection(card, cardType: cardType)
+        self?.viewModel.moveDifferentSection(card, to: cardType)
       })
       .disposed(by: disposeBag)
     
@@ -205,7 +205,7 @@ final class CardListViewController: UIViewController {
       .withUnretained(self)
       .flatMap { wself, item in wself.showPopover(cell: item.0, card: item.1) }
       .bind(onNext: { [weak self] card, cardType in
-        self?.viewModel.moveToOtherSection(card, cardType: cardType)
+        self?.viewModel.moveDifferentSection(card, to: cardType)
       })
       .disposed(by: disposeBag)
     
@@ -213,7 +213,7 @@ final class CardListViewController: UIViewController {
       .withUnretained(self)
       .flatMap { wself, item in wself.showPopover(cell: item.0, card: item.1) }
       .bind(onNext: { [weak self] card, cardType in
-        self?.viewModel.moveToOtherSection(card, cardType: cardType)
+        self?.viewModel.moveDifferentSection(card, to: cardType)
       })
       .disposed(by: disposeBag)
   }

--- a/ProjectManager/ProjectManager/Scene/MainScene/ViewModel/CardListViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/MainScene/ViewModel/CardListViewModel.swift
@@ -84,11 +84,7 @@ final class DefaultCardListViewModel: CardListViewModelable {
   
   func moveToOtherSection(_ card: Card, cardType: CardType) {
     var newCard = card
-    switch cardType {
-    case .todo: newCard.cardType = .todo
-    case .doing: newCard.cardType = .doing
-    case .done: newCard.cardType = .done
-    }
+    newCard.cardType = cardType
     self.updateSelectedCard(newCard)
   }
 }

--- a/ProjectManager/ProjectManager/Scene/MainScene/ViewModel/CardListViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/MainScene/ViewModel/CardListViewModel.swift
@@ -15,7 +15,7 @@ protocol CardListViewModelInput {
   func createNewCard(_ card: Card)
   func updateSelectedCard(_ card: Card)
   func deleteSelectedCard(_ card: Card)
-  func moveToOtherSection(_ card: Card, cardType: CardType)
+  func moveDifferentSection(_ card: Card, to cardType: CardType)
 }
 
 protocol CardListViewModelOutput {
@@ -82,7 +82,7 @@ final class DefaultCardListViewModel: CardListViewModelable {
     cards.accept(cards.value.filter { $0.id != card.id })
   }
   
-  func moveToOtherSection(_ card: Card, cardType: CardType) {
+  func moveDifferentSection(_ card: Card, to cardType: CardType) {
     var newCard = card
     newCard.cardType = cardType
     self.updateSelectedCard(newCard)

--- a/ProjectManager/ProjectManager/Scene/MainScene/ViewModel/CardListViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/MainScene/ViewModel/CardListViewModel.swift
@@ -15,6 +15,7 @@ protocol CardListViewModelInput {
   func createNewCard(_ card: Card)
   func updateSelectedCard(_ card: Card)
   func deleteSelectedCard(_ card: Card)
+  func moveToOtherSection(_ card: Card, cardType: CardType)
 }
 
 protocol CardListViewModelOutput {
@@ -79,6 +80,16 @@ final class DefaultCardListViewModel: CardListViewModelable {
   
   func deleteSelectedCard(_ card: Card) {
     cards.accept(cards.value.filter { $0.id != card.id })
+  }
+  
+  func moveToOtherSection(_ card: Card, cardType: CardType) {
+    var newCard = card
+    switch cardType {
+    case .todo: newCard.cardType = .todo
+    case .doing: newCard.cardType = .doing
+    case .done: newCard.cardType = .done
+    }
+    self.updateSelectedCard(newCard)
   }
 }
 

--- a/ProjectManager/ProjectManager/Scene/MainScene/ViewModel/CardListViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/MainScene/ViewModel/CardListViewModel.swift
@@ -23,9 +23,9 @@ protocol CardListViewModelOutput {
   var doneCards: Driver<[Card]> { get }
 }
 
-protocol CardListViewModel: CardListViewModelInput, CardListViewModelOutput {}
+protocol CardListViewModelable: CardListViewModelInput, CardListViewModelOutput {}
 
-final class DefaultCardListViewModel: CardListViewModel {
+final class DefaultCardListViewModel: CardListViewModelable {
   private let cards = BehaviorRelay<[Card]>(value: Card.sample)
   
   // MARK: - Output

--- a/ProjectManager/ProjectManager/Util/Extension/UITableView+Extension.swift
+++ b/ProjectManager/ProjectManager/Util/Extension/UITableView+Extension.swift
@@ -1,0 +1,8 @@
+//
+//  UITableView+Extension.swift
+//  ProjectManager
+//
+//  Created by Lingo on 2022/07/10.
+//
+
+import Foundation

--- a/ProjectManager/ProjectManager/Util/Extension/UITableView+Extension.swift
+++ b/ProjectManager/ProjectManager/Util/Extension/UITableView+Extension.swift
@@ -5,4 +5,28 @@
 //  Created by Lingo on 2022/07/10.
 //
 
-import Foundation
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+extension Reactive where Base: UITableView {
+  func modelLongPressed<T>(_ modelType: T.Type) -> ControlEvent<(UITableViewCell, T)> {
+    let gesture = UILongPressGestureRecognizer(target: nil, action: nil)
+    base.addGestureRecognizer(gesture)
+    let source = gesture.rx.event
+      .filter { $0.state == .began }
+      .map { base.indexPathForRow(at: $0.location(in: base)) }
+      .flatMap { [weak view = base as UITableView] indexPath -> Observable<(UITableViewCell, T)> in
+        guard let view = view,
+              let indexPath = indexPath,
+              let cell = view.cellForRow(at: indexPath) else { return Observable.empty() }
+        return Observable.zip(
+          Observable.just(cell),
+          Observable.just(try view.rx.model(at: indexPath))
+        )
+      }
+    
+    return ControlEvent(events: source)
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,192 @@
-## iOS 커리어 스타터 캠프
+# 프로젝트 매니저
 
-### 프로젝트 관리 앱 저장소
+## 소개
+해야할 일을 `TODO`, `DOING`, `DONE`으로 관리하는 프로젝트 매니저입니다.
 
-- 이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다
+
+## 프로젝트 기간
+> 2022.07.04(월) ~ 2022.07.15(금) 리뷰어: [린생](https://github.com/jungseungyeo)
 
 
+## 목차
+- [1. 트러블 슈팅](#트러블-슈팅-/-고민한-점)
+- [2. 실행화면](#실행화면)
+- [3. 기술 스택(DB) 선택 과정](#DB-선택-과정)
+
+
+## 기술 스택
+<img width="600px" src="https://i.imgur.com/T9L9x8d.png"/>
+
+
+## PR 및 코드 리뷰
+|STEP 1|STEP 2|
+|:---:|:---:|
+|[STEP 1](https://github.com/yagom-academy/ios-project-manager/pull/120)|[STEP2-1](https://github.com/yagom-academy/ios-project-manager/pull/131)|
+||[STEP2-2](https://github.com/yagom-academy/ios-project-manager/pull/136)|
+||[STEP2-3](https://github.com/yagom-academy/ios-project-manager/pull/137)|
+
+
+## 트러블 슈팅 / 고민한 점
+
+RxSwift와 MVVM, Input/Output 패턴을 적용해보면서 다음의 고민이 있었습니다.
+
+1. Stream이 ViewModel에서 끝나지 않고 ViewController에서 끝날 수 있도록 해야하는가?
+2. Stream이 분기되면서 불필요한 곳에도 Reload가 되고 있지 않을까?
+
+**Stream이 ViewModel에서 끝나지 않고 ViewController에서 끝날 수 있도록 해야하는가?**
+Input/Output 패턴을 공부하면서 어느 블로그 글에서는 <U>ViewModel과 ViewController 둘다 DisposeBag을 프로퍼티에 구현하여 Stream이 종료</U> 될 수 있도록 하는 곳도 있었고 <U>ViewController에서 출발한 Stream이 ViewModel에서 dispose 되지 않고 ViewController에서 dispose 될 수 있도록 구성</U> 해야한다는 의견도 있어 어떻게 구성해야할 지 헷갈리는 부분이 있었습니다.
+
+만약, ViewController에서 Stream을 끝나도록 해야하고 ViewModel에서 Stream이 끝나야하는 경우 아래와 같이 ViewController의 disposeBag을 가져와서 끝내줘야할 지 고민을 하게 되었습니다.
+```swift
+func transform(input: Input, disposeBag: DisposeBag) -> Output
+```
+
+**Stream이 분기되면서 불필요한 곳에도 Reload가 되고 있지 않을까?**
+기존에는 한 개의 Card 배열을 CardType을 기준으로 필터링을 하여 각각의 TableView들에게 이어지도록 Stream을 구성했었습니다. Todo를 추가하면 Doing, Done TableView 모두에게 불필요한 영향을 Reload를 하고 있다는 것을 확인하였고 `distinctUntilChanged()`로 변경점이 있을때만 방출할 수 있도록 변경했습니다.
+
+
+**상속과 Composition 구조**
+새로운 카드를 생성하기 위한 Form과 카드의 상세내용을 표시하는 Form의 UI가 일치하기 때문에 공통 요소 재사용을 어떤 방식으로 구현해야할 지 다음의 방식 중 고민했습니다.
+
+1. **상속(Inheritance) 구조**를 통한 공통 요소 재사용
+2. **합성(Composition) 구조**를 통한 재사용
+
+이 중 Composition 구조를 통해 재사용되는 공통 요소를 뽑아냈습니다. 상속 구조를 채택하지 않은 이유는 다음과 같습니다.
+
+상속 구조는 공통 요소를 재사용하기 매우 편하고 쉽게 구현할 수 있는 방식이지만 기능 개발이 계속 진행되면 될수록 버그가 발생하게 되고 어디서 문제가 발생했는지 파악하기 어렵게 되는 단점이 있고 상속을 하기 위해서는 부모 클래스의 프로퍼티나 메소드를 `private`로 캡슐화가 불가능하다는 점 또한 상속을 채택하지 않은 이유입니다.
+
+<img width="400" src="https://i.imgur.com/dp8Hpnl.png"/> <br/>
+
+따라서, 공통 UI 요소를 CardEditView로 분리한 후 프로퍼티로 생성해주었습니다.
+
+**Compostion 구조**로 구현하면서 느낀점은 교체하기 편리할 것 같다는 생각이 들었습니다. 
+예를 들어, 구현이 필요한 각 영역을 Mock View를 프로퍼티로 생성 후 오토레이아웃을 잡아놓고 추후에 구현이 완료된 View로 교체해서 넣어주면 마치 부품을 조립하듯이 UI를 구성할 수 있겠다는 생각이 들었습니다.
+
+**MVVM Input/Output 구조**
+
+```swift
+protocol ViewModelType {
+  associatedtype Input
+  associatedtype Output
+    
+  func transform(input: Input) -> Output
+}
+```
+
+이전 STEP2-1에서 구현된 ViewModelType 타입과 transform 메서드를 통한 처리 방식은 ViewModel 교체와 테스트를 어렵게 만들고 기능이 많아질수록 transform에서 구현되어야할 코드의 양이 기하급수적으로 증가하게되어 ViewModel이 Massive 하게될 가능성이 있는 구조였습니다.
+
+<img width="600" src="https://i.imgur.com/uwQDMXg.png"/> <br/>
+
+위와 같이 구조로 변경하여 ViewModel를 사용하는 곳에서는 ViewModel 프로토콜을 바라보고 있기 때문에 교체가 용이하게되어 테스트하기 쉽고 
+
+<img width="350" src="https://i.imgur.com/nmAAIT8.png"/> <br/>
+
+`transform` 메서드만으로 전달되는 구조가 아니기 때문에 유연하게 데이터를 전달할 수 있게 되었습니다.
+
+
+**화면 전환에 대한 고민**
+기능 개발이 이뤄지면서 띄워야하는 장면이 증가하고 `present/dismiss` 또는 `push/pop`을 호출해야하는 상황에서 새로운 ViewController를 생성하여 화면 전환을 하게 되는데 
+
+화면을 전환하기 위해서는 해당 ViewController가 다른 ViewController를 소유하고 있어야 하기 때문에 <U>서로 간의 의존성이 증가</U>하고 이곳 저곳에서 구현되어 있는 <U>화면 전환 코드를 관리하기 힘들어질 것 같</U>습니다.
+
+화면 전환 문제에 대해 Coordinator 패턴을 하나의 해결책으로 제시하는 글들을 찾을 수 있었고 이번 STEP2-3에서는 적용하지 못했지만 남은 기간동안 Coordinator 패턴 적용과 Coordinator를 통한 의존성 주입에 대해 고민해보면 좋을 것 같다는 생각이 들었습니다.
+
+**ViewModel과 ViewController**
+
+프로젝트 코드에서 CardListViewController, CardAdditionViewController, CardDetailViewController가 하나의 CardListViewModel 객체를 주입 받는 형태로 구현되어 있고 이렇게 구현된 이유로는 Card를 저장하는 배열을 각각의 ViewController에서 공유해야하기 때문에 1:1이 아닌 1:N의 구조가 되었다고 생각합니다.
+
+ViewModel과 ViewController가 1:N으로 구현이 되어 있다면 CardListViewController에서 사용하지 않는 로직이 CardListViewModel에 구현되어 있는 문제가 있다고 생각했습니다. 하지만, 1:1로 분리하게 된다면 데이터 공유 문제와 중복 로직이 발생할 가능성이 있을 것이며 이를 해결하기 위해 `DataManager`로 공유가 필요한 데이터를 관리하는 계층을 더 추가하는 것도 데이터 공유 문제를 해결할 수 있는 좋은 방법일 것 같습니다.🤔
+
+
+## 실행화면
+
+|[메인 화면] 앱 시작|[메인 화면] 한국어 설정|
+|:---:|:---:|
+|<img width="800" src="https://i.imgur.com/iRV42qz.gif"/>|<img width="800" src="https://i.imgur.com/VKxPymY.png"/>|
+
+|[메인 화면] 영어 설정|[메인 화면] 일본어 설정|
+|:---:|:---:|
+|<img width="800" src="https://i.imgur.com/hSF72A1.png"/>|<img width="800" src="https://i.imgur.com/m7sf27r.png"/>|
+
+|[메인 화면] 카드 생성|[메인 화면] 카드 생성 취소|
+|:---:|:---:|
+|<img width="800" src="https://i.imgur.com/Kl6SpGJ.gif"/>|<img width="800" src="https://i.imgur.com/n76Ef5k.gif"/>|
+
+|[메인 화면] 카드 수정|[메인 화면] 카드 디테일 - 편집모드 X|
+|:---:|:---:|
+|<img width="800" src="https://i.imgur.com/wRVMNJB.gif"/>|<img width="800" src="https://i.imgur.com/4PoJmjJ.gif"/>|
+
+|[메인 화면] 카드 디테일 - 편집모드 O|[메인 화면] 카드 상세 화면|
+|:---:|:---:|
+|<img width="800" src="https://i.imgur.com/n6zw6mE.gif"/>|<img width="800" src="https://i.imgur.com/JNkvRPK.gif"/>|
+
+|[메인 화면] 카드 Swipe 삭제|[메인 화면] 카드 일반 삭제|
+|:---:|:---:|
+|<img width="800" src="https://i.imgur.com/SztzZ4b.gif"/>|<img width="800" src="https://i.imgur.com/STlPlIs.gif"/>|
+
+|[메인 화면] 카드 팝오버 표시|[메인 화면] 카드 팝오버 Section 이동|
+|:---:|:---:|
+|<img width="800" src="https://i.imgur.com/CoeyFZk.gif"/>|<img width="770" src="https://i.imgur.com/lLARdES.gif"/>|
+
+|[메인 화면] 카드 이동 시 마감 시간순 정렬|
+|:---:|
+|<img width="370" src="https://i.imgur.com/xNVHnq3.gif"/>|
+
+## DB 선택 과정
+
+> 로컬 DB에는 `Core Data` / 원격 DB에는 `Firebase Realtime Database` 로 결정했습니다. 
+
+### 💬 **하위 버전 호환성에는 문제가 없는가?**
+
+✅ [iOS 및 iPad OS 사용 현황](https://developer.apple.com/kr/support/app-store/)을 보면 iPad의 경우 90%이상이 iOS 15 버전을 사용한다는 것을 알 수 있었고 
+Core Data는 iOS 3.0 /  Firebase는 iOS 10.0 부터 지원하기 때문에 하위 버전 호환성 문제는 없다고 판단하였습니다.
+
+|iPhone|iPad|
+|:---:|:---:|
+|<img width="300px" src="https://i.imgur.com/A2mxBmX.png"/>|<img width="315px" src="https://i.imgur.com/ff0XpWg.png"/>|
+
+### 💬 **안정적으로 운용 가능한가?**
+
+✅ Core Data의 경우 Apple의 First-Party 프레임워크이기 때문에 안정적으로 운용 가능할 것으로 판단됩니다.  
+✅ Firebase는 구글의 서비스로써 지속적인 유지보수가 이뤄지고 있고 많은 곳에서 사용되어 검증된 기술이므로 안정적인 운용 가능할 것으로 판단했습니다.
+
+
+### 💬 **미래 지속 가능성이 있는가?**
+
+✅ Core Data의 경우 Apple의 First-Party 프레임워크이기 때문에 지속 가능할 것으로 판단됩니다.   
+⚠️ Firebase는 구글에서 서비스하고 있는 Third-Party이므로 언제든지 종료 가능성이 있다고 생각됩니다. 구글은 성과가 없는 프로젝트에 대해 서비스 종료한 과거 사례가 있기 때문에 완전히 안정적이다 라고 볼 수 없을 것 같습니다. 하지만, Firebase는 충분한 성과를 이룬 프로젝트이고 지속적인 유지보수가 이뤄지고 있으며 아직도 많은 곳에서 사용되고 있기 때문에 지속 가능성이 있다고 생각합니다.
+
+
+### 💬 **리스크를 최소화 할 수 있는가? 알고 있는 리스크는 무엇인가?**
+
+✅ Core Data의 경우 Thread-Safe 하지 않는 리스크가 있기 때문에 관련 기능을 추가적으로 구현하여 최소화할 수 있습니다.
+✅ Firebase의 경우 비용 문제가 발생할 수 있지만 초기 서비스에서는 초과할 가능성이 적을 것으로 예상되어 문제가 없을 것으로 생각됩니다.
+
+
+### 💬 **어떤 의존성 관리도구를 사용하여 관리할 수 있는가?**
+
+대표적인 의존성 관리도구로는 CocoaPod, Carthage, Swift Package Manager(SPM)이 있습니다. 
+SPM은 애플의 First-Party 의존성 관리도구이며 이번 프로젝트에서 사용하기로 정한 라이브러리 모두 지원하고 있기 때문에 SPM을 선택했습니다.
+
+✅ Core Data는 애플의 First-Party 프레임워크이므로 의존성 관리 도구를 사용할 필요가 없습니다.  
+✅ Firebase Realtime Database는 Swift Package Manager를 지원합니다.
+
+
+### 💬 **이 앱의 요구 기능에 적절한 선택인가?**
+
+`Realtime Database`와 `Cloud FireStore` 중 무엇을 선택해야할 지에 대한 다음의 고민이 있었습니다.
+
+1. 어느 것이 프로젝트의 성격에 부합하는가?
+2. 어느 것이 비용 정책에서 유리한가?
+
+**1️⃣ 어느 것이 프로젝트의 성격에 부합하는가?**
+
+<img width="600" src="https://i.imgur.com/WbgwBlL.png"/>
+
+**2️⃣ 어느 것이 비용 정책에서 유리한가?**
+
+|Realtime Database|Cloud FireStore|
+|:---:|:---:|
+|![](https://i.imgur.com/diDJMBM.png)|![](https://i.imgur.com/nPHE2aI.png)|
+
+Cloud FireStore는 `CRUD`를 기준으로 비용을 책정하기 때문에 `CRUD`가 자주 발생한다면 Realtime Database가 유리하고 큰 단위의 데이터 요청이 자주 발생한다면 Firestore가 유리할 것이라고 판단했고 프로젝트의 성격과 각각의 비용 정책을 고려한 결과 **Realtime Database** 로 결정하게 되었습니다.


### PR DESCRIPTION
안녕하세요 린생! @jungseungyeo
프로젝트 매니저 STEP 2-3 PR 보냅니다! 잘 부탁드립니다 🙇🏻

## 배경

- 할일을 길게 터치하여 팝오버 메뉴를 표시합니다
    - 팝오버에 표시하는 메뉴는 상황에 따라 달라집니다
        - TODO의 할일 : Move to DOING / Move to DONE
        - DOING의 할일 : Move to TODO / Move to DONE
        - DONE의 할일 : Move to TODO / Move to DOING
    - 본인의 판단에 따라 팝오버는 액션시트로 대체할 수 있습니다

위 요구사항을 만족시킬 수 있도록 진행했습니다.

## 작업 내용

**할일을 길게 터치하여 팝오버 메뉴를 표시합니다**
> Reactive Extension - `ModelLongPressed`
 
길게 터치하는 이벤트가 전달되기 위해 `UILongPressGestureRecognizer`를 사용하였습니다. 해당 이벤트가 발생하고 팝오버 메뉴를 표시하기 위해 처음에는 UIKit스럽게 Target-Action 방식으로 구현을 시도했었습니다. 하지만, Rx를 제대로 활용하지 못한다고 생각했고 아래 코드와 같이 기능을 확장하여 구현했습니다.
 
<img width="800" src="https://i.imgur.com/GOR0539.png"/> <br/>

`modelLongPressed`라는 메서드를 정의하고 Long 제스처를 Base가 되는 TableView에 추가한 후 제스처 이벤트가 발생하면 아래의 과정으로 데이터를 처리한 후 Cell과 데이터를 방출하도록 설계했습니다.

![](https://i.imgur.com/T6tIfJ6.png)


<img width="600" src="https://i.imgur.com/hCNOJni.png"/> <br/>

구현된 `modelLongPressed`를 ViewController에서 사용하여 길게 터치하는 이벤트에 대한 처리를 ViewModel에서 처리하도록 로직을 분리했습니다.

**팝오버에 표시하는 메뉴는 상황에 따라 달라집니다**

팝오버에 표시하는 메뉴는 현재 카드타입과 다른 종류의 타입을 표시해야 하기 때문에 이를 구별해주는 메서드를 구현했습니다.

<img width="600" src="https://i.imgur.com/zSu1Hei.png"/> <br/>

<img width="600" src="https://i.imgur.com/rdlQBgC.png"/> <br/>


**본인의 판단에 따라 팝오버는 액션시트로 대체할 수 있습니다**

요구사항에 맞게 액션시트를 활용하여 팝오버를 띄우는 AlertController를 생성하고 해당 이벤트는 한번만 띄운 후 사용자가 버튼을 클릭할 때 onNext -> onCompleted 가 진행되어야하기 때문에 Single을 사용하여 구현했습니다.

<img width="800" src="https://i.imgur.com/AUxXUis.png"/> <br/>


**마감 시간 순 정렬**

<img width="500" src="https://i.imgur.com/aDOTNIf.png"/> <br/>

TODO와 DOING의 경우 마감 기간까지 얼마남지 않았거나 지나버린 카드를 상단 쪽, DONE의 경우 오래 전 끝난 카드보다 최근에 끝낸 카드가 상단에 보여줘야 한다고 생각했습니다.

따라서, `sorted`로 각각 TODO, DOING, DONE 배열 데이터를 로직에 맞게 ViewModel에서 정렬해주었습니다.

## 리뷰노트

**화면 전환에 대한 고민**
기능 개발이 이뤄지면서 띄워야하는 장면이 증가하고 `present/dismiss` 또는 `push/pop`을 호출해야하는 상황에서 새로운 ViewController를 생성하여 화면 전환을 하게 되는데 

화면을 전환하기 위해서는 해당 ViewController가 다른 ViewController를 소유하고 있어야 하기 때문에 <U>서로 간의 의존성이 증가</U>하고 이곳 저곳에서 구현되어 있는 <U>화면 전환 코드를 관리하기 힘들어질 것 같</U>습니다.

화면 전환 문제에 대해 Coordinator 패턴을 하나의 해결책으로 제시하는 글들을 찾을 수 있었고 이번 STEP2-3에서는 적용하지 못했지만 남은 기간동안 Coordinator 패턴 적용과 Coordinator를 통한 의존성 주입에 대해 고민해보면 좋을 것 같다는 생각이 들었습니다.

**ViewModel과 ViewController**

프로젝트 코드에서 CardListViewController, CardAdditionViewController, CardDetailViewController가 하나의 CardListViewModel 객체를 주입 받는 형태로 구현되어 있고 이렇게 구현된 이유로는 Card를 저장하는 배열을 각각의 ViewController에서 공유해야하기 때문에 1:1이 아닌 1:N의 구조가 되었다고 생각합니다.

> 질문. ViewModel과 ViewController는 1:1과 1:N 어떠한 구조를 가져가는 것이 좋을까요?

저는 ViewModel과 ViewController가 1:N으로 구현이 되어 있다면 CardListViewController에서 사용하지 않는 로직이 CardListViewModel에 구현되어 있는 문제가 있다고 생각했습니다. 하지만, 1:1로 분리하게 된다면 데이터 공유 문제와 중복 로직이 발생할 가능성이 있을 것이며 이를 해결하기 위해 `DataManager`로 공유가 필요한 데이터를 관리하는 계층을 더 추가하는 것도 데이터 공유 문제를 해결할 수 있는 좋은 방법일 것 같습니다.🤔


**남은 기간에 대해**

**프로젝트 매니저 I**의 기능 구현이 생각보다 빠르게 끝난 것 같습니다.🤩 
하지만 남은 기간동안 아래의 항목에 대해 더 고민해보고 프로젝트에 적용해볼 생각입니다!

1. MVVM 패턴과 RxSwift를 잘 사용하기 위한 학습 진행
2. Coordinator 패턴을 고민해보며 프로젝트에 적용 (화면 전환)
3. ViewModel과 ViewController의 1:1, 1:N 관계에 대한 고민 (PR 피드백)
4. Clean Architecture (클린 아키텍처)

질문사항이 생기면 바로바로 DM이나 PR을 통해 남기겠습니다. 🙇🏻

## 스크린샷 및 영상

|[메인 화면] 카드 팝오버 표시|[메인 화면] 카드 팝오버 Section 이동|
|:---:|:---:|
|<img width="800" src="https://i.imgur.com/CoeyFZk.gif"/>|<img width="770" src="https://i.imgur.com/lLARdES.gif"/>|

|[메인 화면] 카드 이동 시 마감 시간순 정렬|
|:---:|
|<img width="370" src="https://i.imgur.com/xNVHnq3.gif"/>|