### PR TITLE
프로젝트 관리 앱 II [STEP 1-2] OneTool, marisol

### DIFF
--- a/ProjectManager.xcodeproj/project.pbxproj
+++ b/ProjectManager.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		B32C993028899AAC00C1F891 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32C992F28899AAB00C1F891 /* ViewModelType.swift */; };
 		B335136B287579DF00BF3495 /* SheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B335136A287579DF00BF3495 /* SheetView.swift */; };
 		B38E432B28915A4B00D276A1 /* History.swift in Sources */ = {isa = PBXBuildFile; fileRef = B38E432A28915A4B00D276A1 /* History.swift */; };
+		B38E432D28915C7000D276A1 /* HistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B38E432C28915C7000D276A1 /* HistoryViewModel.swift */; };
 		B39F102A2873DDC100475AE4 /* ProjectManagerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39F10292873DDC100475AE4 /* ProjectManagerApp.swift */; };
 		B39F102C2873DDC100475AE4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39F102B2873DDC100475AE4 /* ContentView.swift */; };
 		B39F102E2873DDC300475AE4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B39F102D2873DDC300475AE4 /* Assets.xcassets */; };
@@ -42,6 +43,7 @@
 		B32C992F28899AAB00C1F891 /* ViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelType.swift; sourceTree = "<group>"; };
 		B335136A287579DF00BF3495 /* SheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetView.swift; sourceTree = "<group>"; };
 		B38E432A28915A4B00D276A1 /* History.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = History.swift; sourceTree = "<group>"; };
+		B38E432C28915C7000D276A1 /* HistoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HistoryViewModel.swift; path = ProjectManager/View/HistoryViewModel.swift; sourceTree = SOURCE_ROOT; };
 		B39F10262873DDC100475AE4 /* ProjectManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ProjectManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B39F10292873DDC100475AE4 /* ProjectManagerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectManagerApp.swift; sourceTree = "<group>"; };
 		B39F102B2873DDC100475AE4 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -101,6 +103,7 @@
 			children = (
 				B32C992F28899AAB00C1F891 /* ViewModelType.swift */,
 				B32142B82887D7F300F8CBE9 /* ContentViewModel.swift */,
+				B38E432C28915C7000D276A1 /* HistoryViewModel.swift */,
 				B32142BC2887DCBB00F8CBE9 /* ListViewModel.swift */,
 				B32142C42887E6EB00F8CBE9 /* RegisterViewModel.swift */,
 				B32142C22887E18900F8CBE9 /* EditViewModel.swift */,
@@ -311,6 +314,7 @@
 				DA6A312D2889C081008AFA28 /* HeaderView.swift in Sources */,
 				B3CA0B79287D09ED0047E1D1 /* TaskManagementService.swift in Sources */,
 				B3BDBB51287FA82E0072933E /* RegisterView.swift in Sources */,
+				B38E432D28915C7000D276A1 /* HistoryViewModel.swift in Sources */,
 				B32C993028899AAC00C1F891 /* ViewModelType.swift in Sources */,
 				B335136B287579DF00BF3495 /* SheetView.swift in Sources */,
 				DA79E414287525C3000192CC /* ListRowView.swift in Sources */,

--- a/ProjectManager.xcodeproj/project.pbxproj
+++ b/ProjectManager.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		B3CA0B7B287D0A620047E1D1 /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CA0B7A287D0A620047E1D1 /* Task.swift */; };
 		B3CA0B7E287D0FE90047E1D1 /* Date+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CA0B7D287D0FE90047E1D1 /* Date+extension.swift */; };
 		B3EA5F12287481F6000713F7 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = B3EA5F11287481F6000713F7 /* GoogleService-Info.plist */; };
+		DA626F902893A87F00490848 /* ListRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA626F8F2893A87F00490848 /* ListRowViewModel.swift */; };
 		DA6A312D2889C081008AFA28 /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA6A312C2889C081008AFA28 /* HeaderView.swift */; };
 		DA79E414287525C3000192CC /* ListRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA79E413287525C3000192CC /* ListRowView.swift */; };
 		DA79E41A28755DC6000192CC /* NavigationBarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA79E41928755DC6000192CC /* NavigationBarModifier.swift */; };
@@ -58,6 +59,7 @@
 		B3CA0B7D287D0FE90047E1D1 /* Date+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+extension.swift"; sourceTree = "<group>"; };
 		B3EA5F11287481F6000713F7 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		B9E1EE52A77CD8A59090782B /* Pods_ProjectManager.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ProjectManager.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA626F8F2893A87F00490848 /* ListRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListRowViewModel.swift; sourceTree = "<group>"; };
 		DA6A312C2889C081008AFA28 /* HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
 		DA79E413287525C3000192CC /* ListRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListRowView.swift; sourceTree = "<group>"; };
 		DA79E41928755DC6000192CC /* NavigationBarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarModifier.swift; sourceTree = "<group>"; };
@@ -109,6 +111,7 @@
 				B32142BC2887DCBB00F8CBE9 /* ListViewModel.swift */,
 				B32142C42887E6EB00F8CBE9 /* RegisterViewModel.swift */,
 				B32142C22887E18900F8CBE9 /* EditViewModel.swift */,
+				DA626F8F2893A87F00490848 /* ListRowViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -313,6 +316,7 @@
 				B32429F52890123B00BA5700 /* ListView.swift in Sources */,
 				B38E4329289156DA00D276A1 /* HistoryView.swift in Sources */,
 				B32142C32887E18900F8CBE9 /* EditViewModel.swift in Sources */,
+				DA626F902893A87F00490848 /* ListRowViewModel.swift in Sources */,
 				B3CA0B7B287D0A620047E1D1 /* Task.swift in Sources */,
 				B3B28F4328756B1000A3CB57 /* EditView.swift in Sources */,
 				DA6A312D2889C081008AFA28 /* HeaderView.swift in Sources */,

--- a/ProjectManager.xcodeproj/project.pbxproj
+++ b/ProjectManager.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		B32429F52890123B00BA5700 /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32429F42890123B00BA5700 /* ListView.swift */; };
 		B32C993028899AAC00C1F891 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32C992F28899AAB00C1F891 /* ViewModelType.swift */; };
 		B335136B287579DF00BF3495 /* SheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B335136A287579DF00BF3495 /* SheetView.swift */; };
+		B38E432B28915A4B00D276A1 /* History.swift in Sources */ = {isa = PBXBuildFile; fileRef = B38E432A28915A4B00D276A1 /* History.swift */; };
 		B39F102A2873DDC100475AE4 /* ProjectManagerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39F10292873DDC100475AE4 /* ProjectManagerApp.swift */; };
 		B39F102C2873DDC100475AE4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39F102B2873DDC100475AE4 /* ContentView.swift */; };
 		B39F102E2873DDC300475AE4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B39F102D2873DDC300475AE4 /* Assets.xcassets */; };
@@ -40,6 +41,7 @@
 		B32429F42890123B00BA5700 /* ListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
 		B32C992F28899AAB00C1F891 /* ViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelType.swift; sourceTree = "<group>"; };
 		B335136A287579DF00BF3495 /* SheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetView.swift; sourceTree = "<group>"; };
+		B38E432A28915A4B00D276A1 /* History.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = History.swift; sourceTree = "<group>"; };
 		B39F10262873DDC100475AE4 /* ProjectManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ProjectManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B39F10292873DDC100475AE4 /* ProjectManagerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectManagerApp.swift; sourceTree = "<group>"; };
 		B39F102B2873DDC100475AE4 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -161,6 +163,7 @@
 			children = (
 				DA79E41928755DC6000192CC /* NavigationBarModifier.swift */,
 				B3CA0B7A287D0A620047E1D1 /* Task.swift */,
+				B38E432A28915A4B00D276A1 /* History.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -296,6 +299,7 @@
 			files = (
 				B3CA0B7E287D0FE90047E1D1 /* Date+extension.swift in Sources */,
 				DA79E41A28755DC6000192CC /* NavigationBarModifier.swift in Sources */,
+				B38E432B28915A4B00D276A1 /* History.swift in Sources */,
 				B39F102C2873DDC100475AE4 /* ContentView.swift in Sources */,
 				B32142B92887D7F300F8CBE9 /* ContentViewModel.swift in Sources */,
 				B39F102A2873DDC100475AE4 /* ProjectManagerApp.swift in Sources */,

--- a/ProjectManager.xcodeproj/project.pbxproj
+++ b/ProjectManager.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		B32429F52890123B00BA5700 /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32429F42890123B00BA5700 /* ListView.swift */; };
 		B32C993028899AAC00C1F891 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32C992F28899AAB00C1F891 /* ViewModelType.swift */; };
 		B335136B287579DF00BF3495 /* SheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B335136A287579DF00BF3495 /* SheetView.swift */; };
+		B38E4329289156DA00D276A1 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B38E4328289156DA00D276A1 /* HistoryView.swift */; };
 		B38E432B28915A4B00D276A1 /* History.swift in Sources */ = {isa = PBXBuildFile; fileRef = B38E432A28915A4B00D276A1 /* History.swift */; };
 		B38E432D28915C7000D276A1 /* HistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B38E432C28915C7000D276A1 /* HistoryViewModel.swift */; };
 		B39F102A2873DDC100475AE4 /* ProjectManagerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39F10292873DDC100475AE4 /* ProjectManagerApp.swift */; };
@@ -42,6 +43,7 @@
 		B32429F42890123B00BA5700 /* ListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
 		B32C992F28899AAB00C1F891 /* ViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelType.swift; sourceTree = "<group>"; };
 		B335136A287579DF00BF3495 /* SheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetView.swift; sourceTree = "<group>"; };
+		B38E4328289156DA00D276A1 /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryView.swift; sourceTree = "<group>"; };
 		B38E432A28915A4B00D276A1 /* History.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = History.swift; sourceTree = "<group>"; };
 		B38E432C28915C7000D276A1 /* HistoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HistoryViewModel.swift; path = ProjectManager/View/HistoryViewModel.swift; sourceTree = SOURCE_ROOT; };
 		B39F10262873DDC100475AE4 /* ProjectManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ProjectManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -175,6 +177,7 @@
 			isa = PBXGroup;
 			children = (
 				B39F102B2873DDC100475AE4 /* ContentView.swift */,
+				B38E4328289156DA00D276A1 /* HistoryView.swift */,
 				B32429F42890123B00BA5700 /* ListView.swift */,
 				DA79E413287525C3000192CC /* ListRowView.swift */,
 				B3BDBB50287FA82E0072933E /* RegisterView.swift */,
@@ -308,6 +311,7 @@
 				B39F102A2873DDC100475AE4 /* ProjectManagerApp.swift in Sources */,
 				B32142BD2887DCBB00F8CBE9 /* ListViewModel.swift in Sources */,
 				B32429F52890123B00BA5700 /* ListView.swift in Sources */,
+				B38E4329289156DA00D276A1 /* HistoryView.swift in Sources */,
 				B32142C32887E18900F8CBE9 /* EditViewModel.swift in Sources */,
 				B3CA0B7B287D0A620047E1D1 /* Task.swift in Sources */,
 				B3B28F4328756B1000A3CB57 /* EditView.swift in Sources */,

--- a/ProjectManager/Extension/Date+extension.swift
+++ b/ProjectManager/Extension/Date+extension.swift
@@ -8,16 +8,28 @@
 import Foundation
 
 extension Date {
-    var convertDateToString: String {
-        let dateFormatter = DateFormatter()
-        
-        dateFormatter.locale = .autoupdatingCurrent
-        dateFormatter.timeZone = .autoupdatingCurrent
-        dateFormatter.dateFormat = "yyyy. MM. dd."
-        
-        let stringDate = dateFormatter.string(from: self)
-        
-        return stringDate
-        
-    }
+  var convertDateToString: String {
+    let dateFormatter = DateFormatter()
+    
+    dateFormatter.locale = .autoupdatingCurrent
+    dateFormatter.timeZone = .autoupdatingCurrent
+    dateFormatter.dateFormat = "yyyy. MM. dd."
+    
+    let stringDate = dateFormatter.string(from: self)
+    
+    return stringDate
+  }
+  
+  var convertTimeToString: String {
+    let dateFormatter = DateFormatter()
+    
+    dateFormatter.locale = Locale.init(identifier: "en_US")
+    dateFormatter.timeZone = .autoupdatingCurrent
+    dateFormatter.dateStyle = .long
+    dateFormatter.timeStyle = .medium
+    
+    let stringDate = dateFormatter.string(from: self)
+    
+    return stringDate
+  }
 }

--- a/ProjectManager/Model/History.swift
+++ b/ProjectManager/Model/History.swift
@@ -8,7 +8,8 @@
 import RealmSwift
 import Foundation
 
-class History: Object {
+class History: Object, ObjectKeyIdentifiable {
+  @Persisted(primaryKey: true) var id = UUID()
   @Persisted var title: String
   @Persisted var from: TaskType?
   @Persisted var to: TaskType?

--- a/ProjectManager/Model/History.swift
+++ b/ProjectManager/Model/History.swift
@@ -1,0 +1,43 @@
+//
+//  History.swift
+//  ProjectManager
+//
+//  Created by OneTool, marisol on 2022/07/27.
+//
+
+import RealmSwift
+import Foundation
+
+class History: Object {
+  @Persisted var title: String
+  @Persisted var from: TaskType?
+  @Persisted var to: TaskType?
+  @Persisted var date: Date
+  @Persisted var type: HistoryType
+  
+  convenience init(title: String, from: TaskType?, to: TaskType?, date: Date, type: HistoryType) {
+    self.init()
+    self.title = title
+    self.from = from
+    self.to = to
+    self.date = date
+    self.type = type
+  }
+}
+
+enum HistoryType: String, PersistableEnum {
+  case add
+  case move
+  case remove
+  
+  var title: String {
+    switch self {
+    case .add:
+      return "Added"
+    case .move:
+      return "Moved"
+    case .remove:
+      return "Removed"
+    }
+  }
+}

--- a/ProjectManager/Model/Task.swift
+++ b/ProjectManager/Model/Task.swift
@@ -5,17 +5,18 @@
 //  Created by OneTool, marisol on 2022/07/12.
 //
 
-import Foundation
+import RealmSwift
 
-struct Task: Identifiable, Equatable {
-  let id = UUID()
-  var title: String
-  var date: Date
-  var body: String
-  var type: TaskType
-  var isOverdate: Bool
+class Task: Object, ObjectKeyIdentifiable {
+  @Persisted(primaryKey: true) var id = UUID()
+  @Persisted var title: String
+  @Persisted var date: Date
+  @Persisted var body: String
+  @Persisted var type: TaskType
+  @Persisted var isOverdate: Bool
   
-  init(title: String, date: Date, body: String, type: TaskType) {
+  convenience init(title: String, date: Date, body: String, type: TaskType) {
+    self.init()
     self.title = title
     self.date = date
     self.body = body
@@ -24,7 +25,7 @@ struct Task: Identifiable, Equatable {
   }
 }
 
-enum TaskType: Identifiable, CaseIterable {
+enum TaskType: String, Identifiable ,PersistableEnum {
   case todo
   case doing
   case done

--- a/ProjectManager/Model/Task.swift
+++ b/ProjectManager/Model/Task.swift
@@ -21,7 +21,7 @@ class Task: Object, ObjectKeyIdentifiable {
     self.date = date
     self.body = body
     self.type = type
-    self.isOverdate = (self.type == .done) && (self.date + (60*60*24) < Date()) == true
+    self.isOverdate = (self.type != .done) && (self.date + (60*60*24) < Date()) == true
   }
 }
 

--- a/ProjectManager/Service/TaskManagementService.swift
+++ b/ProjectManager/Service/TaskManagementService.swift
@@ -18,8 +18,8 @@ class TaskManagementService {
     } catch {
       print(error)
     }
-    self.allHistories = self.readAllHistories()
-    self.allTasks = self.readAllTasks()
+    self.allHistories = readAllHistories()
+    self.allTasks = readAllTasks()
   }
   
 
@@ -36,10 +36,10 @@ class TaskManagementService {
                               date: Date(),
                               type: .add)
         realm?.add(history)
-        self.allHistories = self.readAllHistories()
+        self.allHistories = readAllHistories()
         
         realm?.add(task)
-        self.allTasks = self.readAllTasks()
+        self.allTasks = readAllTasks()
       })
     } catch {
       print(error)

--- a/ProjectManager/Service/TaskManagementService.swift
+++ b/ProjectManager/Service/TaskManagementService.swift
@@ -18,6 +18,7 @@ class TaskManagementService {
     } catch {
       print(error)
     }
+    self.allHistories = self.readAllHistories()
     self.allTasks = self.readAllTasks()
   }
   
@@ -39,7 +40,6 @@ class TaskManagementService {
         
         realm?.add(task)
         self.allTasks = self.readAllTasks()
-        
       })
     } catch {
       print(error)
@@ -121,5 +121,6 @@ class TaskManagementService {
     } catch {
       print(error)
     }
+    self.allTasks = readAllTasks()
   }
 }

--- a/ProjectManager/Service/TaskManagementService.swift
+++ b/ProjectManager/Service/TaskManagementService.swift
@@ -66,6 +66,7 @@ class TaskManagementService {
     do {
       try realm?.write({
         realm?.delete(task)
+        self.tasks = read()
       })
     } catch {
       print(error)

--- a/ProjectManager/Service/TaskManagementService.swift
+++ b/ProjectManager/Service/TaskManagementService.swift
@@ -74,6 +74,7 @@ class TaskManagementService {
         tasks[index].body = task.body
         tasks[index].date = task.date
         tasks[index].type = task.type
+        tasks[index].isOverdate = (task.type != .done) && (task.date + (60*60*24) < Date()) == true
       })
     } catch {
       print(error)
@@ -109,9 +110,13 @@ class TaskManagementService {
                               type: .move)
         realm?.add(history)
         self.allHistories = readAllHistories()
-        
+
         task.type = type
-        self.allTasks = readAllTasks()
+        if type == .done {
+          task.isOverdate = false
+        } else if (task.date + (60*60*24) < Date()) == true {
+          task.isOverdate = true
+        }
       })
     } catch {
       print(error)

--- a/ProjectManager/View/ContentView.swift
+++ b/ProjectManager/View/ContentView.swift
@@ -27,7 +27,7 @@ struct ContentView: View {
         .toolbar {
           ToolbarItem(placement: .navigationBarTrailing) {
             Button(action: {
-              contentViewModel.toggleShowingSheet()
+              contentViewModel.plusButtonTapped()
             }) {
               Image(systemName: "plus")
                 .imageScale(.large)

--- a/ProjectManager/View/ContentView.swift
+++ b/ProjectManager/View/ContentView.swift
@@ -35,6 +35,15 @@ struct ContentView: View {
               RegisterView(registerViewModel: RegisterViewModel(withService: contentViewModel.service))
             }
           }
+          ToolbarItem(placement: .navigationBarLeading) {
+            Button(action: {
+              contentViewModel.historyButtonTapped()
+            }) {
+              Text("History")
+            }.popover(isPresented: $contentViewModel.isShowingHistory) {
+              HistoryView(historyViewModel: HistoryViewModel(withService: contentViewModel.service))
+            }
+          }
         }
     }
     .navigationViewStyle(.stack)

--- a/ProjectManager/View/ContentView.swift
+++ b/ProjectManager/View/ContentView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ContentView: View {
-  @ObservedObject var contentViewModel: ContentViewModel
+  @ObservedObject private(set) var contentViewModel: ContentViewModel
   
   var body: some View {
     NavigationView {

--- a/ProjectManager/View/HistoryView.swift
+++ b/ProjectManager/View/HistoryView.swift
@@ -12,9 +12,12 @@ struct HistoryView: View {
   
     var body: some View {
       List {
-        VStack(alignment: .leading) {
-          Text(historyViewModel.showHistory())
-          Text("Mar 11, 2020 3:32:07 PM")
+        ForEach(historyViewModel.allHistories) { history in
+          VStack(alignment: .leading) {
+            Text(historyViewModel.showHistory(history))
+            Text(historyViewModel.showDate(history))
+              .foregroundColor(.gray)
+          }
         }
       }
       .frame(width: 500, height: 300)

--- a/ProjectManager/View/HistoryView.swift
+++ b/ProjectManager/View/HistoryView.swift
@@ -1,0 +1,29 @@
+//
+//  HistoryView.swift
+//  ProjectManager
+//
+//  Created by OneTool, marisol on 2022/07/27.
+//
+
+import SwiftUI
+
+struct HistoryView: View {
+  @ObservedObject var historyViewModel: HistoryViewModel
+  
+    var body: some View {
+      List {
+        VStack(alignment: .leading) {
+          Text(historyViewModel.showHistory())
+          Text("Mar 11, 2020 3:32:07 PM")
+        }
+      }
+      .frame(width: 500, height: 300)
+      .listStyle(.grouped)
+    }
+}
+
+struct HistoryView_Previews: PreviewProvider {
+    static var previews: some View {
+      HistoryView(historyViewModel: HistoryViewModel(withService: TaskManagementService()))
+    }
+}

--- a/ProjectManager/View/HistoryView.swift
+++ b/ProjectManager/View/HistoryView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct HistoryView: View {
-  @ObservedObject var historyViewModel: HistoryViewModel
+  @ObservedObject private(set) var historyViewModel: HistoryViewModel
   
     var body: some View {
       List {

--- a/ProjectManager/View/HistoryViewModel.swift
+++ b/ProjectManager/View/HistoryViewModel.swift
@@ -6,9 +6,8 @@
 //
 
 import Foundation
-import SwiftUI
 
-class HistoryViewModel: ViewModelType {
+final class HistoryViewModel: ViewModelType {
   @Published var allHistories: [History] = []
   
   override init(withService: TaskManagementService) {

--- a/ProjectManager/View/HistoryViewModel.swift
+++ b/ProjectManager/View/HistoryViewModel.swift
@@ -12,7 +12,7 @@ final class HistoryViewModel: ViewModelType {
   
   override init(withService: TaskManagementService) {
     super.init(withService: withService)
-    self.allHistories = withService.allHistories
+    self.allHistories = withService.allHistories.reversed()
   }
   
   func showHistory(_ history: History) -> String {

--- a/ProjectManager/View/HistoryViewModel.swift
+++ b/ProjectManager/View/HistoryViewModel.swift
@@ -11,17 +11,21 @@ import SwiftUI
 class HistoryViewModel: ViewModelType {
   @Published var allHistories: [History] = []
   
-  func showHistory() -> String {
+  override init(withService: TaskManagementService) {
+    super.init(withService: withService)
+    self.allHistories = withService.allHistories
+  }
+  
+  func showHistory(_ history: History) -> String {
     var result: String = ""
-    self.allHistories = service.allHistories
     
-    allHistories.forEach { history in
-      switch history.type {
-      case .add, .remove:
-        result = "\(history.type.title) '\(history.title)'"
-      case .move:
-        result = "\(history.type.title) '\(history.title)' from \(history.from ?? .todo) to \(history.to ?? .todo)"
-      }
+    switch history.type {
+    case .add:
+      result = "\(history.type.title) '\(history.title)'."
+    case .move:
+      result = "\(history.type.title) '\(history.title)' from \(history.from?.title ?? "") to \(history.to?.title ?? "")."
+    case .remove:
+      result = "\(history.type.title) '\(history.title)' from \(history.from?.title ?? "")."
     }
     return result
   }

--- a/ProjectManager/View/HistoryViewModel.swift
+++ b/ProjectManager/View/HistoryViewModel.swift
@@ -29,4 +29,9 @@ class HistoryViewModel: ViewModelType {
     }
     return result
   }
+  
+  func showDate(_ history: History) -> String {
+    let currentDate = Date().convertTimeToString
+    return currentDate
+  }
 }

--- a/ProjectManager/View/HistoryViewModel.swift
+++ b/ProjectManager/View/HistoryViewModel.swift
@@ -1,0 +1,28 @@
+//
+//  HistoryViewModel.swift
+//  ProjectManager
+//
+//  Created by OneTool, marisol on 2022/07/27.
+//
+
+import Foundation
+import SwiftUI
+
+class HistoryViewModel: ViewModelType {
+  @Published var allHistories: [History] = []
+  
+  func showHistory() -> String {
+    var result: String = ""
+    self.allHistories = service.allHistories
+    
+    allHistories.forEach { history in
+      switch history.type {
+      case .add, .remove:
+        result = "\(history.type.title) '\(history.title)'"
+      case .move:
+        result = "\(history.type.title) '\(history.title)' from \(history.from ?? .todo) to \(history.to ?? .todo)"
+      }
+    }
+    return result
+  }
+}

--- a/ProjectManager/View/ListRowView.swift
+++ b/ProjectManager/View/ListRowView.swift
@@ -12,6 +12,7 @@ struct ListRowView: View {
   let taskBody: String
   let taskDate: Date
   let isOverdate: Bool
+  @ObservedObject private(set) var listRowViewModel: ListRowViewModel
   
   var body: some View {
     VStack(alignment: .leading) {
@@ -26,6 +27,7 @@ struct ListRowView: View {
   func checkOverdate() -> some View {
     if isOverdate {
       return Text(taskDate.convertDateToString)
+  private func checkOverdate() -> some View {
         .foregroundColor(.red)
     } else {
       return Text(taskDate.convertDateToString)

--- a/ProjectManager/View/ListRowView.swift
+++ b/ProjectManager/View/ListRowView.swift
@@ -8,40 +8,66 @@
 import SwiftUI
 
 struct ListRowView: View {
-  let taskTitle: String
-  let taskBody: String
-  let taskDate: Date
-  let isOverdate: Bool
   @ObservedObject private(set) var listRowViewModel: ListRowViewModel
   
   var body: some View {
     VStack(alignment: .leading) {
-      Text(taskTitle)
+      Text(listRowViewModel.task.title)
         .foregroundColor(.black)
-      Text(taskBody)
+      Text(listRowViewModel.task.body)
         .foregroundColor(.gray)
       checkOverdate()
     }
+    .onTapGesture {
+      listRowViewModel.cellTapped()
+    }
+    .sheet(isPresented: $listRowViewModel.isShowingSheet) {
+      EditView(editViewModel: EditViewModel(withService: listRowViewModel.service, task: listRowViewModel.task))
+      
+    }
+    .onLongPressGesture(minimumDuration: 1) {
+      listRowViewModel.cellLongPressed()
+    }
+    .popover(isPresented: $listRowViewModel.isShowingPopover,
+             arrowEdge: .bottom) {
+      PopoverButton(taskType: listRowViewModel.task.type) { type in
+        listRowViewModel.moveButtonTapped(listRowViewModel.task, type: type)
+      }
+    }
+    
   }
   
-  func checkOverdate() -> some View {
-    if isOverdate {
-      return Text(taskDate.convertDateToString)
   private func checkOverdate() -> some View {
+    if listRowViewModel.task.isOverdate {
+      return Text(listRowViewModel.task.date.convertDateToString)
         .foregroundColor(.red)
     } else {
-      return Text(taskDate.convertDateToString)
+      return Text(listRowViewModel.task.date.convertDateToString)
         .foregroundColor(.black)
     }
   }
 }
 
+struct PopoverButton: View {
+  let taskType: TaskType
+  let moveButtonTapped: (_ to: TaskType) -> Void
+  
+  var body: some View {
+    Form {
+      ForEach(TaskType.allCases.filter{ $0 != taskType }, content: { type in
+        Button(action: {
+          moveButtonTapped(type)
+        }, label: {
+          Text("Move to \(type.title)")
+        })
+      })
+    }.frame(width: 200, height: 150, alignment: .center)
+  }
+}
+
 struct ListRowView_Previews: PreviewProvider {
   static var previews: some View {
-    ListRowView(taskTitle: "title",
-                taskBody: "body",
-                taskDate: Date(),
-                isOverdate: true)
+    ListRowView(listRowViewModel: ListRowViewModel(withService: TaskManagementService(), task: Task()))
       .previewLayout(.sizeThatFits)
   }
 }

--- a/ProjectManager/View/ListRowView.swift
+++ b/ProjectManager/View/ListRowView.swift
@@ -34,7 +34,6 @@ struct ListRowView: View {
         listRowViewModel.moveButtonTapped(listRowViewModel.task, type: type)
       }
     }
-    
   }
   
   private func checkOverdate() -> some View {

--- a/ProjectManager/View/ListView.swift
+++ b/ProjectManager/View/ListView.swift
@@ -21,13 +21,13 @@ struct ListView: View {
                         taskDate: task.date,
                         isOverdate: task.isOverdate)
             .onTapGesture {
-              listViewModel.toggleShowingSheet()
+              listViewModel.cellTapped()
             }
             .sheet(isPresented: $listViewModel.isShowingSheet) {
               EditView(editViewModel: EditViewModel(withService: listViewModel.service, task: task))
             }
             .onLongPressGesture(minimumDuration: 1) {
-              listViewModel.toggleShowingPopover()
+              listViewModel.cellLongPressed()
             }
             .popover(isPresented: $listViewModel.isShowingPopover,
                      arrowEdge: .bottom) {

--- a/ProjectManager/View/ListView.swift
+++ b/ProjectManager/View/ListView.swift
@@ -20,21 +20,21 @@ struct ListView: View {
                         taskBody: task.body,
                         taskDate: task.date,
                         isOverdate: task.isOverdate)
-              .onTapGesture {
-                listViewModel.toggleShowingSheet()
+            .onTapGesture {
+              listViewModel.toggleShowingSheet()
+            }
+            .sheet(isPresented: $listViewModel.isShowingSheet) {
+              EditView(editViewModel: EditViewModel(withService: listViewModel.service, task: task))
+            }
+            .onLongPressGesture(minimumDuration: 1) {
+              listViewModel.toggleShowingPopover()
+            }
+            .popover(isPresented: $listViewModel.isShowingPopover,
+                     arrowEdge: .bottom) {
+              PopoverButton(taskType: listViewModel.taskType) { type in
+                listViewModel.moveTask(task, type: type)
               }
-              .sheet(isPresented: $listViewModel.isShowingSheet) {
-                EditView(editViewModel: EditViewModel(withService: listViewModel.service, task: task))
-              }
-              .onLongPressGesture(minimumDuration: 1) {
-                listViewModel.toggleShowingPopover()
-              }
-              .popover(isPresented: $listViewModel.isShowingPopover,
-                       arrowEdge: .bottom) {
-                PopoverButton(taskType: listViewModel.taskType) { to in
-                  listViewModel.moveTask(task, to: to)
-                }
-              }
+            }
           }
           .onDelete { offset in
             listViewModel.service.tasks.remove(atOffsets: offset)

--- a/ProjectManager/View/ListView.swift
+++ b/ProjectManager/View/ListView.swift
@@ -14,52 +14,17 @@ struct ListView: View {
     VStack(alignment: .leading) {
       List {
         Section(header: HeaderView(title: listViewModel.taskType.title,
-                                   numberOfTasks: listViewModel.readTasks().count)){
-          ForEach(listViewModel.readTasks()) { task in
-            ListRowView(taskTitle: task.title,
-                        taskBody: task.body,
-                        taskDate: task.date,
-                        isOverdate: task.isOverdate)
-            .onTapGesture {
-              listViewModel.cellTapped()
-            }
-            .sheet(isPresented: $listViewModel.isShowingSheet) {
-              EditView(editViewModel: EditViewModel(withService: listViewModel.service, task: task))
-            }
-            .onLongPressGesture(minimumDuration: 1) {
-              listViewModel.cellLongPressed()
-            }
-            .popover(isPresented: $listViewModel.isShowingPopover,
-                     arrowEdge: .bottom) {
-              PopoverButton(taskType: listViewModel.taskType) { type in
-                listViewModel.moveTask(task, type: type)
-              }
-            }
+                                   numberOfTasks: listViewModel.filteredTasks.count)){
+          ForEach(listViewModel.filteredTasks) { task in
+            ListRowView(listRowViewModel: ListRowViewModel(withService: listViewModel.service, task: task))
           }
           .onDelete { index in
-            listViewModel.swipedCell(index: index)
+            listViewModel.deleteCell(index: index)
           }
         }
       }
       .listStyle(.grouped)
     }
-  }
-}
-
-struct PopoverButton: View {
-  let taskType: TaskType
-  let moveTask: (_ to: TaskType) -> Void
-  
-  var body: some View {
-    Form {
-      ForEach(TaskType.allCases.filter{ $0 != taskType }, content: { type in
-        Button(action: {
-          moveTask(type)
-        }, label: {
-          Text("Move to \(type.title)")
-        })
-      })
-    }.frame(width: 200, height: 150, alignment: .center)
   }
 }
 

--- a/ProjectManager/View/ListView.swift
+++ b/ProjectManager/View/ListView.swift
@@ -36,8 +36,8 @@ struct ListView: View {
               }
             }
           }
-          .onDelete { offset in
-            listViewModel.service.tasks.remove(atOffsets: offset)
+          .onDelete { index in
+            listViewModel.swipedCell(index: index)
           }
         }
       }

--- a/ProjectManager/View/ListView.swift
+++ b/ProjectManager/View/ListView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ListView: View {
-  @ObservedObject var listViewModel: ListViewModel
+  @ObservedObject private(set) var listViewModel: ListViewModel
   
   var body: some View {
     VStack(alignment: .leading) {

--- a/ProjectManager/View/RegisterView.swift
+++ b/ProjectManager/View/RegisterView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct RegisterView: View {
   @Environment(\.presentationMode) var presentationMode
-  @ObservedObject var registerViewModel: RegisterViewModel
+  @ObservedObject private(set) var registerViewModel: RegisterViewModel
   
   var body: some View {
     NavigationView {

--- a/ProjectManager/View/SheetView.swift
+++ b/ProjectManager/View/SheetView.swift
@@ -12,7 +12,7 @@ struct SheetView: View {
   @Binding var taskBody: String
   @Binding var taskDate: Date
   
-  var dateRange: ClosedRange<Date> {
+  private var dateRange: ClosedRange<Date> {
     let min = Calendar.current.date(byAdding: .year, value: -1, to: Date()) ?? Date()
     let max = Calendar.current.date(byAdding: .year, value: 1, to: Date().addingTimeInterval(60*60*24*365)) ?? Date()
     

--- a/ProjectManager/ViewModel/ContentViewModel.swift
+++ b/ProjectManager/ViewModel/ContentViewModel.swift
@@ -5,9 +5,9 @@
 //  Created by OneTool, marisol on 2022/07/20.
 //
 
-import SwiftUI
+import Foundation
 
-class ContentViewModel: ViewModelType {
+final class ContentViewModel: ViewModelType {
   @Published var isShowingSheet = false
   @Published var isShowingHistory = false
   

--- a/ProjectManager/ViewModel/ContentViewModel.swift
+++ b/ProjectManager/ViewModel/ContentViewModel.swift
@@ -9,8 +9,13 @@ import SwiftUI
 
 class ContentViewModel: ViewModelType {
   @Published var isShowingSheet = false
+  @Published var isShowingHistory = false
   
-  func toggleShowingSheet() {
+  func plusButtonTapped() {
     isShowingSheet.toggle()
+  }
+  
+  func historyButtonTapped() {
+    isShowingHistory.toggle()
   }
 }

--- a/ProjectManager/ViewModel/EditViewModel.swift
+++ b/ProjectManager/ViewModel/EditViewModel.swift
@@ -5,17 +5,14 @@
 //  Created by OneTool, marisol on 2022/07/20.
 //
 
-import SwiftUI
+import Foundation
 
-class EditViewModel: ViewModelType {
-  @Published var title: String = ""
-  @Published var body: String = ""
-  @Published var date: Date = Date()
-  var task: Task = Task(title: "", date: Date(), body: "", type: .todo)
+final class EditViewModel: ViewModelType {
+  @Published var task: Task
   
   init(withService: TaskManagementService, task: Task) {
-    super.init(withService: withService)
     self.task = task
+    super.init(withService: withService)
   }
   
   func doneButtonTapped() {

--- a/ProjectManager/ViewModel/EditViewModel.swift
+++ b/ProjectManager/ViewModel/EditViewModel.swift
@@ -19,6 +19,6 @@ class EditViewModel: ViewModelType {
   }
   
   func doneButtonTapped() {
-    self.service.editTask(task: task)
+    self.service.update(task: task)
   }
 }

--- a/ProjectManager/ViewModel/ListRowViewModel.swift
+++ b/ProjectManager/ViewModel/ListRowViewModel.swift
@@ -1,0 +1,31 @@
+//
+//  ListRowViewModel.swift
+//  ProjectManager
+//
+//  Created by 김태훈 on 2022/07/29.
+//
+
+import Foundation
+
+final class ListRowViewModel: ViewModelType {
+  @Published var isShowingSheet: Bool = false
+  @Published var isShowingPopover = false
+  var task: Task
+  
+  init(withService: TaskManagementService, task: Task) {
+    self.task = task
+    super.init(withService: withService)
+  }
+  
+  func cellTapped() {
+    isShowingSheet.toggle()
+  }
+  
+  func cellLongPressed() {
+    isShowingPopover.toggle()
+  }
+  
+  func moveButtonTapped(_ task: Task, type: TaskType) {
+    self.service.move(task, type: type)
+  }
+}

--- a/ProjectManager/ViewModel/ListViewModel.swift
+++ b/ProjectManager/ViewModel/ListViewModel.swift
@@ -7,10 +7,8 @@
 
 import Foundation
 
-class ListViewModel: ViewModelType {
-  @Published var isShowingSheet = false
-  @Published var isShowingPopover = false
-  @Published var tasks: [Task] = []
+final class ListViewModel: ViewModelType {
+  @Published var filteredTasks: [Task] = []
   @Published var taskType: TaskType = .todo
   
   init(withService: TaskManagementService, taskType: TaskType) {

--- a/ProjectManager/ViewModel/ListViewModel.swift
+++ b/ProjectManager/ViewModel/ListViewModel.swift
@@ -10,7 +10,8 @@ import Foundation
 class ListViewModel: ViewModelType {
   @Published var isShowingSheet = false
   @Published var isShowingPopover = false
-  var taskType = TaskType.todo
+  @Published var tasks: [Task] = []
+  @Published var taskType: TaskType = .todo
   
   init(withService: TaskManagementService, taskType: TaskType) {
     super.init(withService: withService)
@@ -27,6 +28,7 @@ class ListViewModel: ViewModelType {
   
   func moveTask(_ task: Task, type: TaskType) {
     self.service.move(task, type: type)
+    self.tasks = service.tasks
   }
   
   func readTasks() -> [Task] {
@@ -34,10 +36,10 @@ class ListViewModel: ViewModelType {
   }
   
   func swipedCell(index: IndexSet) {
-    let tasks = service.read()
-    let filterTasks = tasks.filter({ $0.type == taskType })
-    let taskToDelete = filterTasks[index.first ?? 0]
-    
-    service.delete(task: taskToDelete)
+    index.forEach({ index in
+      let taskToDelete = readTasks()[index]
+      service.delete(task: taskToDelete)
+    })
+    self.tasks = service.tasks
   }
 }

--- a/ProjectManager/ViewModel/ListViewModel.swift
+++ b/ProjectManager/ViewModel/ListViewModel.swift
@@ -16,6 +16,7 @@ class ListViewModel: ViewModelType {
   init(withService: TaskManagementService, taskType: TaskType) {
     super.init(withService: withService)
     self.taskType = taskType
+    self.tasks = service.allTasks
   }
   
   func cellTapped() {
@@ -28,7 +29,6 @@ class ListViewModel: ViewModelType {
   
   func moveTask(_ task: Task, type: TaskType) {
     self.service.move(task, type: type)
-    self.tasks = service.allTasks
   }
   
   func readTasks() -> [Task] {

--- a/ProjectManager/ViewModel/ListViewModel.swift
+++ b/ProjectManager/ViewModel/ListViewModel.swift
@@ -18,21 +18,21 @@ class ListViewModel: ViewModelType {
     self.taskType = taskType
   }
   
-  func toggleShowingSheet() {
+  func cellTapped() {
     isShowingSheet.toggle()
   }
   
-  func toggleShowingPopover() {
+  func cellLongPressed() {
     isShowingPopover.toggle()
   }
   
   func moveTask(_ task: Task, type: TaskType) {
     self.service.move(task, type: type)
-    self.tasks = service.tasks
+    self.tasks = service.allTasks
   }
   
   func readTasks() -> [Task] {
-    self.service.read().filter { $0.type == taskType }
+    self.service.readAllTasks().filter { $0.type == taskType }
   }
   
   func swipedCell(index: IndexSet) {
@@ -40,6 +40,6 @@ class ListViewModel: ViewModelType {
       let taskToDelete = readTasks()[index]
       service.delete(task: taskToDelete)
     })
-    self.tasks = service.tasks
+    self.tasks = service.allTasks
   }
 }

--- a/ProjectManager/ViewModel/ListViewModel.swift
+++ b/ProjectManager/ViewModel/ListViewModel.swift
@@ -14,30 +14,14 @@ final class ListViewModel: ViewModelType {
   init(withService: TaskManagementService, taskType: TaskType) {
     super.init(withService: withService)
     self.taskType = taskType
-    self.tasks = service.allTasks
+    self.filteredTasks = service.allTasks.filter({ $0.type == taskType })
   }
   
-  func cellTapped() {
-    isShowingSheet.toggle()
-  }
-  
-  func cellLongPressed() {
-    isShowingPopover.toggle()
-  }
-  
-  func moveTask(_ task: Task, type: TaskType) {
-    self.service.move(task, type: type)
-  }
-  
-  func readTasks() -> [Task] {
-    self.service.readAllTasks().filter { $0.type == taskType }
-  }
-  
-  func swipedCell(index: IndexSet) {
+  func deleteCell(index: IndexSet) {
     index.forEach({ index in
-      let taskToDelete = readTasks()[index]
+      let taskToDelete = filteredTasks[index]
       service.delete(task: taskToDelete)
     })
-    self.tasks = service.allTasks
+    self.filteredTasks = service.allTasks.filter({ $0.type == taskType })
   }
 }

--- a/ProjectManager/ViewModel/ListViewModel.swift
+++ b/ProjectManager/ViewModel/ListViewModel.swift
@@ -25,11 +25,19 @@ class ListViewModel: ViewModelType {
     isShowingPopover.toggle()
   }
   
-  func moveTask(_ task: Task, to: TaskType) {
-    self.service.moveTask(task, to: to)
+  func moveTask(_ task: Task, type: TaskType) {
+    self.service.move(task, type: type)
   }
   
   func readTasks() -> [Task] {
-    self.service.readTasks().filter { $0.type == taskType }
+    self.service.read().filter { $0.type == taskType }
+  }
+  
+  func swipedCell(index: IndexSet) {
+    let tasks = service.read()
+    let filterTasks = tasks.filter({ $0.type == taskType })
+    let taskToDelete = filterTasks[index.first ?? 0]
+    
+    service.delete(task: taskToDelete)
   }
 }

--- a/ProjectManager/ViewModel/RegisterViewModel.swift
+++ b/ProjectManager/ViewModel/RegisterViewModel.swift
@@ -5,9 +5,9 @@
 //  Created by OneTool, marisol on 2022/07/20.
 //
 
-import SwiftUI
+import Foundation
 
-class RegisterViewModel: ViewModelType {
+final class RegisterViewModel: ViewModelType {
   @Published var title: String = ""
   @Published var body: String = ""
   @Published var date: Date = Date()

--- a/ProjectManager/ViewModel/RegisterViewModel.swift
+++ b/ProjectManager/ViewModel/RegisterViewModel.swift
@@ -13,6 +13,6 @@ class RegisterViewModel: ViewModelType {
   @Published var date: Date = Date()
   
   func doneButtonTapped() {
-    self.service.addTask(Task(title: title, date: date, body: body, type: .todo))
+    self.service.create(Task(title: title, date: date, body: body, type: .todo))
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,19 +1,27 @@
-# ⏰ 프로젝트 관리 앱 I
+# ⏰ 프로젝트 관리 앱
 
-> 프로젝트 기간: 2022.07.04 ~ 2022.07.15 <br>
+> 프로젝트 기간: 2022.07.04 ~ 2022.07.29 <br>
 > 팀원: [marisol](https://github.com/marisol-develop), [OneTool](https://github.com/kimt4580)
 > 리뷰어: [Tony](https://github.com/Monsteel)
+
+## ✅ 목차
+
+1. [프로젝트 소개](##🔎-프로젝트-소개)
+2. [PR](##👀-PR)
+3. [프로젝트 실행화면](##📺-프로젝트-실행화면)
+4. [개발환경 및 라이브러리](##🛠-개발환경-및-라이브러리)
+5. [키워드](##🔑-키워드)
+6. [전체적인 구조](##📝-전체적인-구조)
+7. [Trouble Shooting](##🚀-trouble-shooting)
 
 ## 🔎 프로젝트 소개
 : Todo, Doing, Done으로 프로젝트를 관리하는 앱
 
-## 📺 프로젝트 실행화면
-
-
 ## 👀 PR
 [STEP 1](https://github.com/yagom-academy/ios-project-manager/pull/129)
-
 [STEP 2](https://github.com/yagom-academy/ios-project-manager/pull/149)
+[STEP 3-1](https://github.com/yagom-academy/ios-project-manager/pull/156)
+[STEP 3-2](https://github.com/yagom-academy/ios-project-manager/pull/165)
 
 ## 🛠 개발환경 및 라이브러리
 - [![swift](https://img.shields.io/badge/swift-5.6-orange)]()
@@ -21,9 +29,9 @@
 - [![iOS](https://img.shields.io/badge/iOS-15.2-red)]()
 
 ## 🔑 키워드
-`SwiftUI` `MVVM` `@ObservedObject` `popover` `onLongPressGesture` `@Published`
+`SwiftUI` `MVVM` `@ObservedObject` `popover` `onLongPressGesture` `@Published` `Realm`
 
-## 📑 구현내용
+## 📺 프로젝트 실행화면
 - 프로젝트 수행을 위한 다양한 기술 (SQLite, CoreData, iCloud, Dropbox, Firebase, Realm, MongoDB)의 장단점을 비교하여 사용할 기술 선정
 - CocoaPod으로 SwiftLint, Realm, Firebase 설치
 
@@ -35,25 +43,38 @@
 | -------- | -------- |
 |![](https://i.imgur.com/dLZIrao.gif) |![](https://i.imgur.com/ZeoK4UG.gif) |
 
+| 5. Task 추가/이동/삭제시 History에 추가 | 6. Realm Studio |
+| -------- | -------- |
+|<img src = https://i.imgur.com/KFGpAPo.gif, width = "100%">| <img src = https://i.imgur.com/nl1e2co.gif, width = "100%">|
+
+
 ## 📝 전체적인 구조
 
-- `TaskViewModel`: Task마다 가지고 있는 ViewModel로, title, date, body변수가 Published로 선언되어 있다
-- `ContentViewModel`: ContentViewModel이 가지고 있는 ViewModel이다. TaskViewModel을 ObservedObject로 갖고 있고, @Published로 선언된 todoTasks, doingTasks, doneTasks를 갖고 있다. 
-    - `appendData()`: TaskViewModel에 접근해 todo/doing/done에 append해주는 메서드
-    - `moveData(_ task: Task, from: TaskType, to: TaskType)`: task를 다른 배열로 이동시켜주는 메서드
-- `ContentView`: `TodoView`, `DoingView`, `DoneView`를 NavigationView > HStack으로 보여주는 뷰
-- `TodoView`, `DoingView`, `DoneView`: 구독하고 있는 contentViewModel에서 자신의 taskType에 맞는 array의 Task 요소들을 CellView를 통해 보여주는 View
-- `CellView`: 위 3가지 타입의 뷰로부터 contentViewModel, cellIndex, taskType을 전달받아 ListRowView로 데이터를 표시하는 뷰
-- `ListRowView`: `CellView`로부터 정보를 전달받아 직접 화면에 Text를 통해 정보를 보여주는 뷰
-- `RegisterView`, `RegisterElementView`: NavigationView인 `RegisterView`가 `RegisterElementView`를 화면에 표시함
-- `EditView`, `EditElementView`: NavigationView인 `EditView`가 선택된 Task의 정보를 `EditElementView`가 화면에 표시함
+- **`Model`**
+    - `Task`: title, date, body, type(todo/doing/done) 정보를 갖고 있는 모델 객체
+    - `History`: 변경 이력에 대한 정보(title, from(taskType), to(taskType), date, type(add/move/remove))을 갖고 있는 모델 객체
+
+- **`View`**
+    - `ContentView`: 3가지`ListView`를 `NavigationView`로 보여주는 가장 상위 View
+    - `HistoryView` : ContentView의 왼쪽 Toolbar 버튼을 클릭하면 보여지는 뷰. added, moved, removed 등의 변경 이력을 보여줌
+    - `ListView`: `TODO`, `DOING`, `DONE` Task별로 LIST를 보여주는 View
+    - `ListRowView`: `ListView`의 각 Cell이며, title, date, body Text를 보여주는 View
+    - `RegisterView` : ContentView의 오른쪽 Toolbar 버튼을 클릭하면 보여지는 뷰. `SheetView`를 표시함
+    - `EditView`: 각 ListView를 tap하면 보여지는 뷰. `RegisterView`와 공동으로 `SheetView`를 사용함
+    - `SheetView` : TextField, DatePicker, TextEditor를 sheet 형식으로 보여주는 뷰
+    - `HeaderView`: 각 TaskType에 맞게 헤더에 텍스트와 Task 갯수를 표시하는 View
+
+- **`Service`**
+    - `TaskManagementService`: 모든 task들이 있는 allTasks 배열과 모든 변경이력이 있는 allHistories을 프로퍼티로 갖는 클래스이며, Realm의 CRUD가 구현되어 있는 객체
+
+- **`ViewModel`**
+    - `ViewModelType`: 모든 ViewModel이 상속받는 ObservableObject 객체로, 모든 ViewModel이 같은 `TaskManagementService`를 참조하도록 해준다
 
 ## 📖 학습한 내용
 
 - Swift Package Manager와 CoCoaPods의 차이 
 
 **Dynamic FrameWork**
-
 <img src = https://i.imgur.com/syk2WY7.png, width = "80%">
 - 동시에 여러 프레임워크 혹은 프로그램에서 공유하여 사용하기 때문에 메모리를 효율적으로 사용
 - 동적으로 연결되어 있으므로, 전체 빌드를 다시 하지 않아도 새로운 프레임워크 사용이 가능
@@ -157,52 +178,6 @@ class ContentViewModel: ObservableObject {
     }
 }
 ```
-
-# ⏰ 프로젝트 관리 앱 II
-
-> 프로젝트 기간: 2022.07.18 ~ 2022.07.29 <br>
-> 팀원: [marisol](https://github.com/marisol-develop), [OneTool](https://github.com/kimt4580)
-> 리뷰어: [Tony](https://github.com/Monsteel)
-
-## 🔎 프로젝트 소개
-: Todo, Doing, Done으로 프로젝트를 관리하는 앱
-
-## 📺 프로젝트 실행화면
-
-
-## 👀 PR
-[STEP 3](https://github.com/yagom-academy/ios-project-manager/pull/156)
-
-
-## 🛠 개발환경 및 라이브러리
-- [![swift](https://img.shields.io/badge/swift-5.6-orange)]()
-- [![xcode](https://img.shields.io/badge/Xcode-13.2.1-blue)]()
-- [![iOS](https://img.shields.io/badge/iOS-15.2-red)]()
-
-## 🔑 키워드
-`SwiftUI` `MVVM` `@ObservedObject` `popover` `onLongPressGesture` `@Published`
-
-## 📝 전체적인 구조
-
-- **`Model`**
-    - `Task`: title, date, body, type(todo/doing/done) 정보를 갖고 있는 모델 객체
-
-- **`View`**
-    - `ContentView`: `AllListView`를 `NavigationView`로 보여주는 가장 상위 View
-    - `AllListView`: `TODO`, `DOING`, `DONE` LIST를 보여주는 View
-    - `CellView`: `AllListView`의 List 내의 각 Cell이며, `ListRowView`에게 정보를 전달해주는 View
-    - `ListRowView`: `CellView`에게 전달받은 정보를 가지고 실제로 title, date, body Text를 보여주는 View
-    - `RegisterView`, `RegisterElementView`: NavigationView인 `RegisterView`가 `RegisterElementView`를 화면에 표시함
-    - `EditView`, `EditElementView`: NavigationView인 `EditView`가 선택된 Task의 정보를 `EditElementView`에게 전달하여 화면에 표시함
-    - `HeaderView`: 각 TaskType에 맞게 헤더에 텍스트와 Task 갯수를 표시하는 View
-
-- **`Service`**
-    - `TaskManagementService`: 모든 task들이 있는 tasks 배열을 프로퍼티로 갖는 클래스이며, 추후에 Realm의 CRUD가 구현될 클래스
-
-- **`ViewModel`**
-    - `ViewModelType`: 모든 ViewModel이 상속받는 ObservableObject 객체로, 모든 ViewModel이 같은 `TaskManagementService`를 참조하도록 해준다
-
-## 🚀 trouble shooting
 ### 📌 어떻게 모든 ViewModel이 같은 Service를 알도록 할수 있을까?
 
 우선 `Todo`, `Doing`, `Done`으로 `array`가 쪼개져있었기 때문에 분기처리를 해줘야할 부분이 많아서 각 `Task`가 자신의 `type`을 알도록 `Task`의 프로퍼티로 `type`을 추가해주었습니다. 그리고 모든 `task`들이 모여있는 `tasks` 배열을 갖고 있는 `TaskManagementService`를 생성했습니다. 
@@ -240,5 +215,42 @@ class ViewModelType: ObservableObject {
 
 [@StateObject, @ObservedObject](https://wondev.tistory.com/5)
 
+### 📌 변경 이력을 어떻게 표시해줄 수 있을까?
 
+- Task가 생성되었을 때, 이동되었을 때, 삭제되었을 때 변경이력을 HistoryView에 표시해주어야했고, History Object를 생성하여 기존 realm의 생성, 삭제 이동시 함께 처리해주도록 구현했습니다. 
+- TaskManagementService에 모든 History들을 갖고있는 allHistories 배열을 생성했습니다. 그리고 Task가 생성될 때, 이동될 때, 삭제될 때 History를 생성해서 realm에 add해주는 방식으로 처리했습니다.
+- HistoryViewModel의 showHistory 메서드에서 history의 type(add / move / remove)에 따라 분기처리하여 String을 리턴하고, HistoryView에서는 해당 String을 받아 Text에 표시만 해주도록 했습니다.
+
+### 📌 realm과 View의 데이터가 동기화 되지 않는 문제
+- 기존의 Service를 realm으로 변경하였을 때, realm에는 저장되지만, View에는 동기화되지 않는 오류가 발생하였습니다. realm이 가진 data와 동기화 해주는 코드를 추가해서 해결해주었습니다.
+```swift
+func swipedCell(index: IndexSet) {
+    index.forEach({ index in
+      let taskToDelete = readTasks()[index]
+      service.delete(task: taskToDelete)
+    })
+    self.tasks = service.allTasks
+  }
+```
+```swift
+realm?.add(history)
+self.allHistories = self.readAllHistories()
+        
+realm?.add(task)
+self.allTasks = readAllTasks()
+```
+
+### 📌 History View Popover의 무한 재귀
+```swift
+ self.allHistories = service.allHistories
+```
+계속해서, 자신을 호출하는 현상으로 무한재귀에 빠져서 App Crash가 발생했습니다.
+```swift
+ override init(withService: TaskManagementService) {
+    super.init(withService: withService)
+    self.allHistories = withService.allHistories
+  }
+
+```
+그로 인해서, 동기화가 무한으로 진행되어서 View를 그릴 수 없었습니다. 메서드를 호출할 때마다 초기화를 해주는 것이 아닌, 처음 실행될 때 한번만 초기화를 하기 위해서 init을 사용하여 초기화 해주었습니다.
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@
 
 ## 👀 PR
 [STEP 1](https://github.com/yagom-academy/ios-project-manager/pull/129)
+
 [STEP 2](https://github.com/yagom-academy/ios-project-manager/pull/149)
+
 [STEP 3-1](https://github.com/yagom-academy/ios-project-manager/pull/156)
+
 [STEP 3-2](https://github.com/yagom-academy/ios-project-manager/pull/165)
 
 ## 🛠 개발환경 및 라이브러리
@@ -75,7 +78,9 @@
 - Swift Package Manager와 CoCoaPods의 차이 
 
 **Dynamic FrameWork**
+
 <img src = https://i.imgur.com/syk2WY7.png, width = "80%">
+
 - 동시에 여러 프레임워크 혹은 프로그램에서 공유하여 사용하기 때문에 메모리를 효율적으로 사용
 - 동적으로 연결되어 있으므로, 전체 빌드를 다시 하지 않아도 새로운 프레임워크 사용이 가능
 - Static Linker를 통해 Dynamic Library Reference가 어플리케이션 코드에 들어가고 모듈 호출시 Stack에 있는 Library에 접근하여 사용
@@ -112,9 +117,13 @@
 하지만 라이브러리는 어떤 특정 기능을 구현하기 위해 미리 만들어진 함수의 집합이며, 필요할 때만 자유롭게 사용할 수 있는 `도구`이다.
 
 참조 : 
+
 [Podfile Syntax Reference](https://guides.cocoapods.org/syntax/podfile.html#use_frameworks_bang)
+
 [Building a dynamic modular iOS architecture](https://medium.com/fluxom/building-a-dynamic-modular-ios-architecture-1b87dc31278b)
+
 [Static, Dynamic Framework](https://velog.io/@dvhuni/Static-Dynamic-Framework)
+
 [프레임워크와 라이브러리 차이점 쉽게 이해하기](https://velog.io/@nemo/framework-library-gfreqbgx)
 
 ## 🚀 trouble shooting


### PR DESCRIPTION
안녕하세요 토니! @Monsteel
Realm을 적용한 STEP 1-2 PR 보냅니다!
이번 리뷰도 잘부탁드립니다~! 🙇‍♀️🙇‍♂️



## 📝 전체적인 구조

- **`Model`**
    - `Task`: title, date, body, type(todo/doing/done) 정보를 갖고 있는 모델 객체
    - `History`: 변경 이력에 대한 정보(title, from(taskType), to(taskType), date, type(add/move/remove))을 갖고 있는 모델 객체

- **`View`**
    - `ContentView`: 3가지`ListView`를 `NavigationView`로 보여주는 가장 상위 View
    - `HistoryView` : ContentView의 왼쪽 Toolbar 버튼을 클릭하면 보여지는 뷰. added, moved, removed 등의 변경 이력을 보여줌
    - `ListView`: `TODO`, `DOING`, `DONE` Task별로 LIST를 보여주는 View
    - `ListRowView`: `ListView`의 각 Cell이며, title, date, body Text를 보여주는 View
    - `RegisterView` : ContentView의 오른쪽 Toolbar 버튼을 클릭하면 보여지는 뷰. `SheetView`를 표시함
    - `EditView`: 각 ListView를 tap하면 보여지는 뷰. `RegisterView`와 공동으로 `SheetView`를 사용함
    - `SheetView` : TextField, DatePicker, TextEditor를 sheet 형식으로 보여주는 뷰
    - `HeaderView`: 각 TaskType에 맞게 헤더에 텍스트와 Task 갯수를 표시하는 View

- **`Service`**
    - `TaskManagementService`: 모든 task들이 있는 allTasks 배열과 모든 변경이력이 있는 allHistories을 프로퍼티로 갖는 클래스이며, Realm의 CRUD가 구현되어 있는 객체

- **`ViewModel`**
    - `ViewModelType`: 모든 ViewModel이 상속받는 ObservableObject 객체로, 모든 ViewModel이 같은 `TaskManagementService`를 참조하도록 해준다

## 🚀 trouble shooting
### 📌 변경 이력을 어떻게 표시해줄 수 있을까?

- Task가 생성되었을 때, 이동되었을 때, 삭제되었을 때 변경이력을 HistoryView에 표시해주어야했고, History Object를 생성하여 기존 realm의 생성, 삭제 이동시 함께 처리해주도록 구현했습니다. 
- TaskManagementService에 모든 History들을 갖고있는 allHistories 배열을 생성했습니다. 그리고 Task가 생성될 때, 이동될 때, 삭제될 때 History를 생성해서 realm에 add해주는 방식으로 처리했습니다.
- HistoryViewModel의 showHistory 메서드에서 history의 type(add / move / remove)에 따라 분기처리하여 String을 리턴하고, HistoryView에서는 해당 String을 받아 Text에 표시만 해주도록 했습니다.

### 📌 realm과 View의 데이터가 동기화 되지 않는 문제
- 기존의 Service를 realm으로 변경하였을 때, realm에는 저장되지만, View에는 동기화되지 않는 오류가 발생하였습니다. realm이 가진 data와 동기화 해주는 코드를 추가해서 해결해주었습니다.
```swift
func swipedCell(index: IndexSet) {
    index.forEach({ index in
      let taskToDelete = readTasks()[index]
      service.delete(task: taskToDelete)
    })
    self.tasks = service.allTasks
  }
```
```swift
realm?.add(history)
self.allHistories = self.readAllHistories()
        
realm?.add(task)
self.allTasks = readAllTasks()
```

### 📌 History View Popover의 무한 재귀
```swift
 self.allHistories = service.allHistories
```
계속해서, 자신을 호출하는 현상으로 무한재귀에 빠져서 App Crash가 발생했습니다.
```swift
 override init(withService: TaskManagementService) {
    super.init(withService: withService)
    self.allHistories = withService.allHistories
  }

```
그로 인해서, 동기화가 무한으로 진행되어서 View를 그릴 수 없었습니다. 메서드를 호출할 때마다 초기화를 해주는 것이 아닌, 처음 실행될 때 한번만 초기화를 하기 위해서 init을 사용하여 초기화 해주었습니다.

### 📌 allHistories와 history
- 기존의 코드에서는 ViewModel에서 allHistories에 대해, ForEach를 돌려주었습니다. 하지만 View를 그릴 때 history의 데이터를 realm에 저장해주고 allHistories의 index 마다 View를 그려줘야한다는 것을 깨달았고, View에서 ForEach를  사용하여 각 index마다 View를 그려주도록 수정해주었습니다.
```swift
//  HistoryView.swift

var body: some View {
      List {
        ForEach(historyViewModel.allHistories) { history in
          VStack(alignment: .leading) {
            Text(historyViewModel.showHistory(history))
            Text(historyViewModel.showDate(history))
              .foregroundColor(.gray)
          }
        }
      }
      .frame(width: 500, height: 300)
      .listStyle(.grouped)
    }
}
```
```swift
//  HistoryViewModel.swift

func showHistory(_ history: History) -> String {
    var result: String = ""
    
    switch history.type {
    case .add:
      result = "\(history.type.title) '\(history.title)'."
    case .move:
      result = "\(history.type.title) '\(history.title)' from \(history.from?.title ?? "") to \(history.to?.title ?? "")."
    case .remove:
      result = "\(history.type.title) '\(history.title)' from \(history.from?.title ?? "")."
    }
    return result
  }
```

## 🧐 궁금한점

### 📌 Task를 이동시켰을 때, 뷰에 바로 반영되지 않는 현상

예를들어 TODO -> DOING으로 뷰를 이동시켰을 때, TODO에서는 바로 해당 Task가 사라진 것이 반영이 되지만, DOING에서는 표시되어야할 Task가 보이지 않습니다.
그래서 ContentView의 ToolbarItem인 +버튼을 누르면 그때서야 DOING에 Task가 표시됩니다.
예측하기로는 +버튼을 눌렀을 때 ContentViewModel의 @Published인 isShowingSheet가 true로 변경되면서 ContentView를 다시 그려서 그때서야 Task가 표시되는게 아닌가 싶습니다 🥲
![](https://i.imgur.com/b3FyCl8.gif)

Task가 이동되었을 때 이동된 ListView에서도 바로 뷰가 업데이트 되려면 어떻게 해야할지 조언 주시면 감사하겠습니다 ㅠㅠ