### PR TITLE
프로젝트 관리 앱 II [STEP 2] Donnie, Grumpy

### DIFF
--- a/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
+++ b/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
@@ -43,7 +43,8 @@
 		9CACE12D28755BE20010E4F0 /* Then.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CACE12C28755BE20010E4F0 /* Then.swift */; };
 		9CACE13228755FDF0010E4F0 /* TaskTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CACE13128755FDF0010E4F0 /* TaskTableViewCell.swift */; };
 		9CACE135287566F30010E4F0 /* UIFont+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CACE134287566F30010E4F0 /* UIFont+extension.swift */; };
-		9CB74188288F79D500153604 /* UnderBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB74187288F79D500153604 /* UnderBarView.swift */; };
+		9CB74188288F79D500153604 /* FooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB74187288F79D500153604 /* FooterView.swift */; };
+		9CB7418A289139FE00153604 /* PopNotificationSendable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB74189289139FE00153604 /* PopNotificationSendable.swift */; };
 		9CBB9AC2288997120037B024 /* SynchronizeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBB9AC1288997120037B024 /* SynchronizeManager.swift */; };
 		C7431F0625F51E1D0094C4CF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7431F0525F51E1D0094C4CF /* AppDelegate.swift */; };
 		C7431F0825F51E1D0094C4CF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7431F0725F51E1D0094C4CF /* SceneDelegate.swift */; };
@@ -82,7 +83,8 @@
 		9CACE12C28755BE20010E4F0 /* Then.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Then.swift; sourceTree = "<group>"; };
 		9CACE13128755FDF0010E4F0 /* TaskTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskTableViewCell.swift; sourceTree = "<group>"; };
 		9CACE134287566F30010E4F0 /* UIFont+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+extension.swift"; sourceTree = "<group>"; };
-		9CB74187288F79D500153604 /* UnderBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnderBarView.swift; sourceTree = "<group>"; };
+		9CB74187288F79D500153604 /* FooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FooterView.swift; sourceTree = "<group>"; };
+		9CB74189289139FE00153604 /* PopNotificationSendable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopNotificationSendable.swift; sourceTree = "<group>"; };
 		9CBB9AC1288997120037B024 /* SynchronizeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizeManager.swift; sourceTree = "<group>"; };
 		C7431F0225F51E1D0094C4CF /* ProjectManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ProjectManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7431F0525F51E1D0094C4CF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -182,7 +184,7 @@
 				4EB3FFD228758E9F0001DBC0 /* MainView.swift */,
 				4EB3FFD0287586200001DBC0 /* TaskHeaderView.swift */,
 				9CACA2BB287FECB50024E923 /* TaskSectionView.swift */,
-				9CB74187288F79D500153604 /* UnderBarView.swift */,
+				9CB74187288F79D500153604 /* FooterView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -268,6 +270,7 @@
 				9C8BC0D828786ECF003EF525 /* RealmManager.swift */,
 				9CBB9AC1288997120037B024 /* SynchronizeManager.swift */,
 				9CACE12C28755BE20010E4F0 /* Then.swift */,
+				9CB7418B28913A0E00153604 /* Protocol */,
 				9CACE133287566D40010E4F0 /* Extension */,
 			);
 			path = Utils;
@@ -281,6 +284,14 @@
 				9CACA2BD28804CEB0024E923 /* UIViewController+extension.swift */,
 			);
 			path = Extension;
+			sourceTree = "<group>";
+		};
+		9CB7418B28913A0E00153604 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				9CB74189289139FE00153604 /* PopNotificationSendable.swift */,
+			);
+			path = Protocol;
 			sourceTree = "<group>";
 		};
 		AE87CCF57CC7FEFBCF5C38F9 /* Pods */ = {
@@ -471,7 +482,7 @@
 				9CACE13228755FDF0010E4F0 /* TaskTableViewCell.swift in Sources */,
 				4EB3FFC228756FDD0001DBC0 /* Task.swift in Sources */,
 				9CACA2BE28804CEB0024E923 /* UIViewController+extension.swift in Sources */,
-				9CB74188288F79D500153604 /* UnderBarView.swift in Sources */,
+				9CB74188288F79D500153604 /* FooterView.swift in Sources */,
 				9CACE12D28755BE20010E4F0 /* Then.swift in Sources */,
 				9CBB9AC2288997120037B024 /* SynchronizeManager.swift in Sources */,
 				C7431F0A25F51E1D0094C4CF /* MainViewController.swift in Sources */,
@@ -487,6 +498,7 @@
 				4E4479FD288A4880001D99A7 /* HistoryViewController.swift in Sources */,
 				4EB2451F2876F589007F4056 /* EditFormSheetViewController.swift in Sources */,
 				4EB89253287C6D2E008DE9B8 /* MainViewModel.swift in Sources */,
+				9CB7418A289139FE00153604 /* PopNotificationSendable.swift in Sources */,
 				C7431F0825F51E1D0094C4CF /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
+++ b/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		4EB595F3287D543D006C8303 /* AppConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB595F2287D543D006C8303 /* AppConstants.swift */; };
 		4EB89251287C68B1008DE9B8 /* PopoverViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB89250287C68B1008DE9B8 /* PopoverViewModel.swift */; };
 		4EB89253287C6D2E008DE9B8 /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB89252287C6D2E008DE9B8 /* MainViewModel.swift */; };
+		4EBAA742289399E8006E57AE /* UserNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EBAA741289399E8006E57AE /* UserNotificationManager.swift */; };
 		4EC236262873DCF9006C9D32 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 4EC236252873DCF9006C9D32 /* RxCocoa */; };
 		4EC236282873DCF9006C9D32 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = 4EC236272873DCF9006C9D32 /* RxRelay */; };
 		4EC2362A2873DCF9006C9D32 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 4EC236292873DCF9006C9D32 /* RxSwift */; };
@@ -74,6 +75,7 @@
 		4EB595F2287D543D006C8303 /* AppConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
 		4EB89250287C68B1008DE9B8 /* PopoverViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverViewModel.swift; sourceTree = "<group>"; };
 		4EB89252287C6D2E008DE9B8 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
+		4EBAA741289399E8006E57AE /* UserNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationManager.swift; sourceTree = "<group>"; };
 		8186A352743ECE68B4046D56 /* Pods-ProjectManager.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProjectManager.debug.xcconfig"; path = "Target Support Files/Pods-ProjectManager/Pods-ProjectManager.debug.xcconfig"; sourceTree = "<group>"; };
 		9C8BC0D828786ECF003EF525 /* RealmManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmManager.swift; sourceTree = "<group>"; };
 		9C8BC0DA287874F3003EF525 /* PopoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverView.swift; sourceTree = "<group>"; };
@@ -275,6 +277,7 @@
 				4EB595F2287D543D006C8303 /* AppConstants.swift */,
 				9C8BC0D828786ECF003EF525 /* RealmManager.swift */,
 				9CBB9AC1288997120037B024 /* SynchronizeManager.swift */,
+				4EBAA741289399E8006E57AE /* UserNotificationManager.swift */,
 				9CACE12C28755BE20010E4F0 /* Then.swift */,
 				9CB7418B28913A0E00153604 /* Protocol */,
 				9CACE133287566D40010E4F0 /* Extension */,
@@ -488,6 +491,7 @@
 				9CB7419128921C3B00153604 /* PushDeleteNotificationSendable.swift in Sources */,
 				9CACA2BC287FECB50024E923 /* TaskSectionView.swift in Sources */,
 				9C8BC0DB287874F3003EF525 /* PopoverView.swift in Sources */,
+				4EBAA742289399E8006E57AE /* UserNotificationManager.swift in Sources */,
 				9C8BC0D928786ED0003EF525 /* RealmManager.swift in Sources */,
 				9CACE13228755FDF0010E4F0 /* TaskTableViewCell.swift in Sources */,
 				4EB3FFC228756FDD0001DBC0 /* Task.swift in Sources */,
@@ -652,6 +656,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ProjectManager/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -672,6 +677,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ProjectManager/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
+++ b/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
@@ -45,6 +45,9 @@
 		9CACE135287566F30010E4F0 /* UIFont+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CACE134287566F30010E4F0 /* UIFont+extension.swift */; };
 		9CB74188288F79D500153604 /* FooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB74187288F79D500153604 /* FooterView.swift */; };
 		9CB7418A289139FE00153604 /* PopNotificationSendable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB74189289139FE00153604 /* PopNotificationSendable.swift */; };
+		9CB7418D28921A3600153604 /* PushMovingNotificationSendable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB7418C28921A3600153604 /* PushMovingNotificationSendable.swift */; };
+		9CB7418F28921B6300153604 /* PushAddNotificationSendable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB7418E28921B6300153604 /* PushAddNotificationSendable.swift */; };
+		9CB7419128921C3B00153604 /* PushDeleteNotificationSendable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB7419028921C3B00153604 /* PushDeleteNotificationSendable.swift */; };
 		9CBB9AC2288997120037B024 /* SynchronizeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBB9AC1288997120037B024 /* SynchronizeManager.swift */; };
 		C7431F0625F51E1D0094C4CF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7431F0525F51E1D0094C4CF /* AppDelegate.swift */; };
 		C7431F0825F51E1D0094C4CF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7431F0725F51E1D0094C4CF /* SceneDelegate.swift */; };
@@ -85,6 +88,9 @@
 		9CACE134287566F30010E4F0 /* UIFont+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+extension.swift"; sourceTree = "<group>"; };
 		9CB74187288F79D500153604 /* FooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FooterView.swift; sourceTree = "<group>"; };
 		9CB74189289139FE00153604 /* PopNotificationSendable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopNotificationSendable.swift; sourceTree = "<group>"; };
+		9CB7418C28921A3600153604 /* PushMovingNotificationSendable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushMovingNotificationSendable.swift; sourceTree = "<group>"; };
+		9CB7418E28921B6300153604 /* PushAddNotificationSendable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushAddNotificationSendable.swift; sourceTree = "<group>"; };
+		9CB7419028921C3B00153604 /* PushDeleteNotificationSendable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushDeleteNotificationSendable.swift; sourceTree = "<group>"; };
 		9CBB9AC1288997120037B024 /* SynchronizeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizeManager.swift; sourceTree = "<group>"; };
 		C7431F0225F51E1D0094C4CF /* ProjectManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ProjectManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7431F0525F51E1D0094C4CF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -290,6 +296,9 @@
 			isa = PBXGroup;
 			children = (
 				9CB74189289139FE00153604 /* PopNotificationSendable.swift */,
+				9CB7418C28921A3600153604 /* PushMovingNotificationSendable.swift */,
+				9CB7418E28921B6300153604 /* PushAddNotificationSendable.swift */,
+				9CB7419028921C3B00153604 /* PushDeleteNotificationSendable.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -476,6 +485,7 @@
 				4EB3FFD328758E9F0001DBC0 /* MainView.swift in Sources */,
 				4EA80EF028802F020054737E /* DatabaseError.swift in Sources */,
 				4EB3FFCD28757E1F0001DBC0 /* FormSheetView.swift in Sources */,
+				9CB7419128921C3B00153604 /* PushDeleteNotificationSendable.swift in Sources */,
 				9CACA2BC287FECB50024E923 /* TaskSectionView.swift in Sources */,
 				9C8BC0DB287874F3003EF525 /* PopoverView.swift in Sources */,
 				9C8BC0D928786ED0003EF525 /* RealmManager.swift in Sources */,
@@ -492,6 +502,7 @@
 				9CACE135287566F30010E4F0 /* UIFont+extension.swift in Sources */,
 				4EB3FFC628757C800001DBC0 /* TaskType.swift in Sources */,
 				4EB595F3287D543D006C8303 /* AppConstants.swift in Sources */,
+				9CB7418F28921B6300153604 /* PushAddNotificationSendable.swift in Sources */,
 				4E4479FF288A6F35001D99A7 /* HistoryCell.swift in Sources */,
 				4E447A01288A7188001D99A7 /* History.swift in Sources */,
 				9CAB1170287C439B00C55AB8 /* NewFormSheetViewModel.swift in Sources */,
@@ -499,6 +510,7 @@
 				4EB2451F2876F589007F4056 /* EditFormSheetViewController.swift in Sources */,
 				4EB89253287C6D2E008DE9B8 /* MainViewModel.swift in Sources */,
 				9CB7418A289139FE00153604 /* PopNotificationSendable.swift in Sources */,
+				9CB7418D28921A3600153604 /* PushMovingNotificationSendable.swift in Sources */,
 				C7431F0825F51E1D0094C4CF /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
+++ b/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		9CACE12D28755BE20010E4F0 /* Then.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CACE12C28755BE20010E4F0 /* Then.swift */; };
 		9CACE13228755FDF0010E4F0 /* TaskTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CACE13128755FDF0010E4F0 /* TaskTableViewCell.swift */; };
 		9CACE135287566F30010E4F0 /* UIFont+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CACE134287566F30010E4F0 /* UIFont+extension.swift */; };
+		9CB74188288F79D500153604 /* UnderBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB74187288F79D500153604 /* UnderBarView.swift */; };
 		9CBB9AC2288997120037B024 /* SynchronizeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBB9AC1288997120037B024 /* SynchronizeManager.swift */; };
 		C7431F0625F51E1D0094C4CF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7431F0525F51E1D0094C4CF /* AppDelegate.swift */; };
 		C7431F0825F51E1D0094C4CF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7431F0725F51E1D0094C4CF /* SceneDelegate.swift */; };
@@ -81,6 +82,7 @@
 		9CACE12C28755BE20010E4F0 /* Then.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Then.swift; sourceTree = "<group>"; };
 		9CACE13128755FDF0010E4F0 /* TaskTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskTableViewCell.swift; sourceTree = "<group>"; };
 		9CACE134287566F30010E4F0 /* UIFont+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+extension.swift"; sourceTree = "<group>"; };
+		9CB74187288F79D500153604 /* UnderBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnderBarView.swift; sourceTree = "<group>"; };
 		9CBB9AC1288997120037B024 /* SynchronizeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizeManager.swift; sourceTree = "<group>"; };
 		C7431F0225F51E1D0094C4CF /* ProjectManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ProjectManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7431F0525F51E1D0094C4CF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -180,6 +182,7 @@
 				4EB3FFD228758E9F0001DBC0 /* MainView.swift */,
 				4EB3FFD0287586200001DBC0 /* TaskHeaderView.swift */,
 				9CACA2BB287FECB50024E923 /* TaskSectionView.swift */,
+				9CB74187288F79D500153604 /* UnderBarView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -468,6 +471,7 @@
 				9CACE13228755FDF0010E4F0 /* TaskTableViewCell.swift in Sources */,
 				4EB3FFC228756FDD0001DBC0 /* Task.swift in Sources */,
 				9CACA2BE28804CEB0024E923 /* UIViewController+extension.swift in Sources */,
+				9CB74188288F79D500153604 /* UnderBarView.swift in Sources */,
 				9CACE12D28755BE20010E4F0 /* Then.swift in Sources */,
 				9CBB9AC2288997120037B024 /* SynchronizeManager.swift in Sources */,
 				C7431F0A25F51E1D0094C4CF /* MainViewController.swift in Sources */,

--- a/ProjectManager/ProjectManager/AppDelegate.swift
+++ b/ProjectManager/ProjectManager/AppDelegate.swift
@@ -10,8 +10,10 @@ import FirebaseCore
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    
     var window: UIWindow?
     static let undoManager = UndoManager()
+    
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?

--- a/ProjectManager/ProjectManager/AppDelegate.swift
+++ b/ProjectManager/ProjectManager/AppDelegate.swift
@@ -11,7 +11,7 @@ import FirebaseCore
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
-    
+    static let undoManager = UndoManager()
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?

--- a/ProjectManager/ProjectManager/Scene/FormSheet/View/FormSheetView.swift
+++ b/ProjectManager/ProjectManager/Scene/FormSheet/View/FormSheetView.swift
@@ -10,13 +10,18 @@ import SnapKit
 
 final class FormSheetView: UIView {
     
+    fileprivate enum Constants {
+        static let titlePlaceholder: String = "Title"
+        static let bodyDefaultValue: String = "입력 가능한 글자수는 1000자로 제한합니다."
+    }
+    
     private lazy var formSheetStackView = UIStackView().then {
         $0.axis = .vertical
         $0.spacing = 10
     }
     
     private(set) lazy var titleTextField = UITextField().then {
-        $0.placeholder = "Title"
+        $0.placeholder = Constants.titlePlaceholder
         $0.backgroundColor = .white
         $0.addLeftPadding()
         setShadow(target: $0)
@@ -34,7 +39,7 @@ final class FormSheetView: UIView {
     
     private(set) lazy var bodyTextView = UITextView().then {
         $0.font = .preferredFont(forTextStyle: .subheadline)
-        $0.text = "입력 가능한 글자수는 1000자로 제한합니다."
+        $0.text = Constants.bodyDefaultValue
     }
     
     override init(frame: CGRect) {

--- a/ProjectManager/ProjectManager/Scene/FormSheet/ViewController/EditFormSheetViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/FormSheet/ViewController/EditFormSheetViewController.swift
@@ -10,6 +10,7 @@ import RxSwift
 import RxCocoa
 
 final class EditFormSheetViewController: UIViewController {
+    
     fileprivate enum Constants {
         static let done: String = "Done"
         static let edit: String = "Edit"

--- a/ProjectManager/ProjectManager/Scene/FormSheet/ViewController/NewFormSheetViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/FormSheet/ViewController/NewFormSheetViewController.swift
@@ -10,6 +10,7 @@ import RxSwift
 import RxCocoa
 
 final class NewFormSheetViewController: UIViewController {
+    
     fileprivate enum Constants {
         static let title: String = "TODO"
         static let done: String = "Done"

--- a/ProjectManager/ProjectManager/Scene/FormSheet/ViewModel/EditFormSheetViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/FormSheet/ViewModel/EditFormSheetViewModel.swift
@@ -21,7 +21,9 @@ protocol EditFormSheetViewModelState {
     var dismiss: PublishRelay<Void> { get }
 }
 
-final class EditFormSheetViewModel: EditFormSheetViewModelEvent, EditFormSheetViewModelState, ErrorObservable {
+final class EditFormSheetViewModel: EditFormSheetViewModelEvent,
+                                        EditFormSheetViewModelState,
+                                        ErrorObservable {
     
     var title: BehaviorRelay<String> = BehaviorRelay(value: AppConstants.defaultStringValue)
     var body: BehaviorRelay<String> = BehaviorRelay(value: AppConstants.defaultStringValue)

--- a/ProjectManager/ProjectManager/Scene/FormSheet/ViewModel/EditFormSheetViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/FormSheet/ViewModel/EditFormSheetViewModel.swift
@@ -34,6 +34,7 @@ final class EditFormSheetViewModel: EditFormSheetViewModelEvent,
     private let reference = Database.database().reference()
     private let realmManager = RealmManager()
     private let undoManager = AppDelegate.undoManager
+    private let userNotificationManager = UserNotificationManager()
     
     func editButtonTapped(task: Task) {
         modifyEditableTask(task: task)
@@ -65,6 +66,7 @@ final class EditFormSheetViewModel: EditFormSheetViewModelEvent,
             before: capturedOriginalTask,
             after: capturedEditedTask
         )
+        userNotificationManager.adjustUserNotificationAboutTypeChange(of: editableTask)
         do {
             try realmManager.update(task: editableTask)
             dismiss.accept(())
@@ -93,6 +95,7 @@ final class EditFormSheetViewModel: EditFormSheetViewModelEvent,
                 before: capturedEditedTask,
                 after: capturedOriginalTask
             )
+            self?.userNotificationManager.adjustUserNotificationAboutTypeChange(of: capturedOriginalTask)
             do {
                 try self?.realmManager.update(task: before)
             } catch {
@@ -117,6 +120,7 @@ final class EditFormSheetViewModel: EditFormSheetViewModelEvent,
             id: after.id
         )
         undoManager.registerUndo(withTarget: self) { [weak self] _ in
+            self?.userNotificationManager.adjustUserNotificationAboutTypeChange(of: capturedOriginalTask)
             self?.registerModifyUndoAction(
                 before: capturedEditedTask,
                 after: capturedOriginalTask

--- a/ProjectManager/ProjectManager/Scene/FormSheet/ViewModel/NewFormSheetViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/FormSheet/ViewModel/NewFormSheetViewModel.swift
@@ -50,7 +50,6 @@ final class NewFormSheetViewModel: NewFormSheetViewModelEvent, NewFormSheetViewM
         
         do {
             try realmManager.create(task: newTask)
-
             sendNotificationForHistory(newTask.title)
             dismiss.accept(())
         } catch {
@@ -60,14 +59,16 @@ final class NewFormSheetViewModel: NewFormSheetViewModelEvent, NewFormSheetViewM
     
     private func registerAddUndoAction(task: Task) {
         undoManager.registerUndo(withTarget: self) { [weak self] _ in
+            let createdTask = Task(
+                title: task.title,
+                body: task.body,
+                date: task.date,
+                taskType: .todo,
+                id: task.id
+            )
+            
             do {
-                let createdTask = Task(
-                    title: task.title,
-                    body: task.body,
-                    date: task.date,
-                    taskType: .todo,
-                    id: task.id
-                )
+                
                 self?.registerAddRedoAction(task: createdTask)
                 try self?.realmManager.delete(task: task)
                 self?.sendNotificationForHistory()
@@ -79,8 +80,9 @@ final class NewFormSheetViewModel: NewFormSheetViewModelEvent, NewFormSheetViewM
     
     private func registerAddRedoAction(task: Task) {
         undoManager.registerUndo(withTarget: self) { [weak self] _ in
+            let title = task.title
+            
             do {
-                let title = task.title
                 self?.registerAddUndoAction(task: task)
                 try self?.realmManager.create(task: task)
                 self?.sendNotificationForHistory(title)

--- a/ProjectManager/ProjectManager/Scene/FormSheet/ViewModel/NewFormSheetViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/FormSheet/ViewModel/NewFormSheetViewModel.swift
@@ -61,18 +61,18 @@ final class NewFormSheetViewModel: NewFormSheetViewModelEvent,
     }
     
     private func registerAddUndoAction(task: Task) {
+        let capturedTask = Task(
+            title: task.title,
+            body: task.body,
+            date: task.date,
+            taskType: .todo,
+            id: task.id
+        )
+        
         undoManager.registerUndo(withTarget: self) { [weak self] _ in
-            let createdTask = Task(
-                title: task.title,
-                body: task.body,
-                date: task.date,
-                taskType: .todo,
-                id: task.id
-            )
-            
+            self?.registerAddRedoAction(task: capturedTask)
             do {
-                self?.registerAddRedoAction(task: createdTask)
-                try self?.realmManager.delete(task: task)
+                try self?.realmManager.delete(task: capturedTask)
                 self?.sendNotificationForHistory()
             } catch {
                 self?.error.accept(DatabaseError.deleteError)
@@ -81,12 +81,19 @@ final class NewFormSheetViewModel: NewFormSheetViewModelEvent,
     }
     
     private func registerAddRedoAction(task: Task) {
+        let capturedTask = Task(
+            title: task.title,
+            body: task.body,
+            date: task.date,
+            taskType: .todo,
+            id: task.id
+        )
+        
         undoManager.registerUndo(withTarget: self) { [weak self] _ in
-            let title = task.title
-            
+            let title = capturedTask.title
+            self?.registerAddUndoAction(task: capturedTask)
             do {
-                self?.registerAddUndoAction(task: task)
-                try self?.realmManager.create(task: task)
+                try self?.realmManager.create(task: capturedTask)
                 self?.sendNotificationForHistory(title)
             } catch {
                 self?.error.accept(DatabaseError.createError)

--- a/ProjectManager/ProjectManager/Scene/FormSheet/ViewModel/NewFormSheetViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/FormSheet/ViewModel/NewFormSheetViewModel.swift
@@ -69,11 +69,12 @@ final class NewFormSheetViewModel: NewFormSheetViewModelEvent,
             taskType: .todo,
             id: task.id
         )
-        
+        let id = capturedTask.id
         undoManager.registerUndo(withTarget: self) { [weak self] _ in
             self?.registerAddRedoAction(task: capturedTask)
             do {
                 try self?.realmManager.delete(task: capturedTask)
+                UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [id])
                 self?.sendNotificationForHistory()
             } catch {
                 self?.error.accept(DatabaseError.deleteError)

--- a/ProjectManager/ProjectManager/Scene/FormSheet/ViewModel/NewFormSheetViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/FormSheet/ViewModel/NewFormSheetViewModel.swift
@@ -60,6 +60,10 @@ final class NewFormSheetViewModel: NewFormSheetViewModelEvent, NewFormSheetViewM
         let content = "Added '\(title)'."
         let time = date.value
         let history: [String: Any] = ["content": content, "time": time]
-        NotificationCenter.default.post(name: NSNotification.Name("History"), object: nil, userInfo: history)
+        NotificationCenter.default.post(name: NSNotification.Name("Push"), object: nil, userInfo: history)
+    }
+    
+    private func sendNotificationForHistory() {
+        NotificationCenter.default.post(name: NSNotification.Name("Pop"), object: nil, userInfo: nil)
     }
 }

--- a/ProjectManager/ProjectManager/Scene/FormSheet/ViewModel/NewFormSheetViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/FormSheet/ViewModel/NewFormSheetViewModel.swift
@@ -24,7 +24,8 @@ protocol NewFormSheetViewModelState {
 final class NewFormSheetViewModel: NewFormSheetViewModelEvent,
                                     NewFormSheetViewModelState,
                                     ErrorObservable,
-                                    PopNotificationSendable {
+                                    PopNotificationSendable,
+                                    PushAddNotificationSendable {
     
     var title: BehaviorRelay<String> = BehaviorRelay(value: AppConstants.defaultStringValue)
     var body: BehaviorRelay<String> = BehaviorRelay(value: AppConstants.defaultStringValue)
@@ -99,12 +100,5 @@ final class NewFormSheetViewModel: NewFormSheetViewModelEvent,
                 self?.error.accept(DatabaseError.createError)
             }
         }
-    }
-    
-    private func sendNotificationForHistory(_ title: String) {
-        let content = "Added '\(title)'."
-        let time = date.value
-        let history: [String: Any] = ["content": content, "time": time]
-        NotificationCenter.default.post(name: NSNotification.Name("PushHistory"), object: nil, userInfo: history)
     }
 }

--- a/ProjectManager/ProjectManager/Scene/FormSheet/ViewModel/NewFormSheetViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/FormSheet/ViewModel/NewFormSheetViewModel.swift
@@ -68,7 +68,6 @@ final class NewFormSheetViewModel: NewFormSheetViewModelEvent, NewFormSheetViewM
             )
             
             do {
-                
                 self?.registerAddRedoAction(task: createdTask)
                 try self?.realmManager.delete(task: task)
                 self?.sendNotificationForHistory()

--- a/ProjectManager/ProjectManager/Scene/FormSheet/ViewModel/NewFormSheetViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/FormSheet/ViewModel/NewFormSheetViewModel.swift
@@ -21,7 +21,10 @@ protocol NewFormSheetViewModelState {
     var dismiss: PublishRelay<Void> { get }
 }
 
-final class NewFormSheetViewModel: NewFormSheetViewModelEvent, NewFormSheetViewModelState, ErrorObservable {
+final class NewFormSheetViewModel: NewFormSheetViewModelEvent,
+                                    NewFormSheetViewModelState,
+                                    ErrorObservable,
+                                    PopNotificationSendable {
     
     var title: BehaviorRelay<String> = BehaviorRelay(value: AppConstants.defaultStringValue)
     var body: BehaviorRelay<String> = BehaviorRelay(value: AppConstants.defaultStringValue)
@@ -95,10 +98,6 @@ final class NewFormSheetViewModel: NewFormSheetViewModelEvent, NewFormSheetViewM
         let content = "Added '\(title)'."
         let time = date.value
         let history: [String: Any] = ["content": content, "time": time]
-        NotificationCenter.default.post(name: NSNotification.Name("Push"), object: nil, userInfo: history)
-    }
-    
-    private func sendNotificationForHistory() {
-        NotificationCenter.default.post(name: NSNotification.Name("Pop"), object: nil, userInfo: nil)
+        NotificationCenter.default.post(name: NSNotification.Name("PushHistory"), object: nil, userInfo: history)
     }
 }

--- a/ProjectManager/ProjectManager/Scene/History/HistoryCell.swift
+++ b/ProjectManager/ProjectManager/Scene/History/HistoryCell.swift
@@ -9,6 +9,7 @@ import UIKit
 import SnapKit
 
 final class HistoryCell: UITableViewCell {
+    
     static var identifier: String {
         return String(describing: self)
     }

--- a/ProjectManager/ProjectManager/Scene/History/HistoryViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/History/HistoryViewController.swift
@@ -34,20 +34,20 @@ final class HistoryViewController: UITableViewController {
     private func setupNotification() {
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(appendHistoryData(notification:)),
-            name: Notification.Name("Push"),
+            selector: #selector(appendHistory(notification:)),
+            name: Notification.Name("PushHistory"),
             object: nil
         )
         
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(removeHistoryData),
-            name: Notification.Name("Pop"),
+            selector: #selector(removeHistory),
+            name: Notification.Name("PopHistory"),
             object: nil
         )
     }
     
-    @objc private func appendHistoryData(notification: Notification) {
+    @objc private func appendHistory(notification: Notification) {
         guard let received = notification.userInfo as? [String: Any],
               let content = received["content"] as? String,
               let time = received["time"] as? Double else {
@@ -58,7 +58,7 @@ final class HistoryViewController: UITableViewController {
         self.tableView.reloadData()
     }
     
-    @objc private func removeHistoryData() {
+    @objc private func removeHistory() {
         self.histories.removeFirst()
         self.tableView.reloadData()
     }

--- a/ProjectManager/ProjectManager/Scene/History/HistoryViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/History/HistoryViewController.swift
@@ -54,13 +54,12 @@ final class HistoryViewController: UITableViewController {
                   return
               }
         let history = History(content: content, time: time)
-        self.histories.append(history)
+        self.histories.insert(history, at: .zero)
         self.tableView.reloadData()
     }
     
     @objc private func removeHistoryData() {
-        
-        self.histories.removeLast()
+        self.histories.removeFirst()
         self.tableView.reloadData()
     }
     

--- a/ProjectManager/ProjectManager/Scene/History/HistoryViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/History/HistoryViewController.swift
@@ -9,6 +9,10 @@ import UIKit
 
 final class HistoryViewController: UITableViewController {
     
+    fileprivate enum Constants {
+        static let title: String = "History"
+    }
+    
     private var histories: [History] = []
     
     override init(style: UITableView.Style) {
@@ -23,7 +27,7 @@ final class HistoryViewController: UITableViewController {
     }
     
     private func configureNavigationItems() {
-        title = "History"
+        title = Constants.title
         navigationItem.hidesBackButton = true
     }
     
@@ -35,22 +39,22 @@ final class HistoryViewController: UITableViewController {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(appendHistory(notification:)),
-            name: Notification.Name("PushHistory"),
+            name: Notification.Name(AppConstants.pushHistoryNotificationName),
             object: nil
         )
         
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(removeHistory),
-            name: Notification.Name("PopHistory"),
+            name: Notification.Name(AppConstants.popHistoryNotificationName),
             object: nil
         )
     }
     
     @objc private func appendHistory(notification: Notification) {
         guard let received = notification.userInfo as? [String: Any],
-              let content = received["content"] as? String,
-              let time = received["time"] as? Double else {
+              let content = received[AppConstants.historyContentKey] as? String,
+              let time = received[AppConstants.historyTimeKey] as? Double else {
                   return
               }
         let history = History(content: content, time: time)
@@ -74,9 +78,7 @@ final class HistoryViewController: UITableViewController {
                 as? HistoryCell else {
             return UITableViewCell()
         }
-        
         cell.setupContents(history: histories[indexPath.row])
-        
         return cell
     }
 }

--- a/ProjectManager/ProjectManager/Scene/History/HistoryViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/History/HistoryViewController.swift
@@ -35,7 +35,14 @@ final class HistoryViewController: UITableViewController {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(appendHistoryData(notification:)),
-            name: Notification.Name("History"),
+            name: Notification.Name("Push"),
+            object: nil
+        )
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(removeHistoryData),
+            name: Notification.Name("Pop"),
             object: nil
         )
     }
@@ -48,6 +55,12 @@ final class HistoryViewController: UITableViewController {
               }
         let history = History(content: content, time: time)
         self.histories.append(history)
+        self.tableView.reloadData()
+    }
+    
+    @objc private func removeHistoryData() {
+        
+        self.histories.removeLast()
         self.tableView.reloadData()
     }
     

--- a/ProjectManager/ProjectManager/Scene/Main/View/FooterView.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/View/FooterView.swift
@@ -10,13 +10,18 @@ import SnapKit
 
 final class FooterView: UIView {
     
+    fileprivate enum Constants {
+        static let undo: String = "Undo"
+        static let redo: String = "Redo"
+    }
+    
     private let baseStackView = UIStackView().then {
         $0.axis = .horizontal
         $0.spacing = 20
     }
     
-    private(set) lazy var undoButton = generateUndoManageButton(title: "Undo")
-    private(set) lazy var redoButton = generateUndoManageButton(title: "Redo")
+    private(set) lazy var undoButton = generateUndoManageButton(title: Constants.undo)
+    private(set) lazy var redoButton = generateUndoManageButton(title: Constants.redo)
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/ProjectManager/ProjectManager/Scene/Main/View/FooterView.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/View/FooterView.swift
@@ -1,5 +1,5 @@
 //
-//  UnderBarView.swift
+//  FooterView.swift
 //  ProjectManager
 //
 //  Created by Donnie, Grump on 2022/07/26.
@@ -8,28 +8,15 @@
 import UIKit
 import SnapKit
 
-final class UnderBarView: UIView {
+final class FooterView: UIView {
     
     private let baseStackView = UIStackView().then {
         $0.axis = .horizontal
         $0.spacing = 20
     }
     
-    private(set) var undoButton = UIButton().then {
-        $0.setTitle("Undo", for: .normal)
-        $0.setTitleColor(.systemBlue, for: .normal)
-        $0.setTitleColor(.gray, for: .disabled)
-        //$0.isEnabled = false
-        $0.titleLabel?.font = .preferredFont(forTextStyle: .title2)
-    }
-    
-    private(set) var redoButton = UIButton().then {
-        $0.setTitle("Redo", for: .normal)
-        $0.setTitleColor(.systemBlue, for: .normal)
-        $0.setTitleColor(.gray, for: .disabled)
-        //$0.isEnabled = false
-        $0.titleLabel?.font = .preferredFont(forTextStyle: .title2)
-    }
+    private(set) lazy var undoButton = generateUndoManageButton(title: "Undo")
+    private(set) lazy var redoButton = generateUndoManageButton(title: "Redo")
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -39,6 +26,15 @@ final class UnderBarView: UIView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func generateUndoManageButton(title: String) -> UIButton {
+        return UIButton().then {
+            $0.setTitle(title, for: .normal)
+            $0.setTitleColor(.systemBlue, for: .normal)
+            $0.setTitleColor(.gray, for: .disabled)
+            $0.titleLabel?.font = .preferredFont(forTextStyle: .title2)
+        }
     }
     
     private func setupSubViews() {

--- a/ProjectManager/ProjectManager/Scene/Main/View/MainView.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/View/MainView.swift
@@ -13,7 +13,7 @@ final class MainView: UIView {
     private(set) lazy var todoView = TaskSectionView(taskType: .todo)
     private(set) lazy var doingView = TaskSectionView(taskType: .doing)
     private(set) lazy var doneView = TaskSectionView(taskType: .done)
-    private(set) lazy var underBarView = UnderBarView()
+    private(set) lazy var footerView = FooterView()
     
     private let baseStackView = UIStackView().then {
         $0.axis = .vertical
@@ -45,7 +45,7 @@ final class MainView: UIView {
         taskSectionStackView.addArrangedSubview(doneView)
         
         baseStackView.addArrangedSubview(taskSectionStackView)
-        baseStackView.addArrangedSubview(underBarView)
+        baseStackView.addArrangedSubview(footerView)
     }
     
     private func setupUILayout() {
@@ -54,7 +54,7 @@ final class MainView: UIView {
             $0.leading.trailing.bottom.equalToSuperview()
         }
         
-        underBarView.snp.makeConstraints {
+        footerView.snp.makeConstraints {
             $0.height.equalTo(baseStackView.snp.height).multipliedBy(0.08)
         }
     }

--- a/ProjectManager/ProjectManager/Scene/Main/View/MainView.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/View/MainView.swift
@@ -13,10 +13,11 @@ final class MainView: UIView {
     private(set) lazy var todoView = TaskSectionView(taskType: .todo)
     private(set) lazy var doingView = TaskSectionView(taskType: .doing)
     private(set) lazy var doneView = TaskSectionView(taskType: .done)
-    private let underBarView = UnderBarView()
+    private(set) lazy var underBarView = UnderBarView()
     
     private let baseStackView = UIStackView().then {
         $0.axis = .vertical
+        $0.spacing = 3
     }
     
     private let taskSectionStackView = UIStackView().then {

--- a/ProjectManager/ProjectManager/Scene/Main/View/MainView.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/View/MainView.swift
@@ -13,12 +13,18 @@ final class MainView: UIView {
     private(set) lazy var todoView = TaskSectionView(taskType: .todo)
     private(set) lazy var doingView = TaskSectionView(taskType: .doing)
     private(set) lazy var doneView = TaskSectionView(taskType: .done)
-
+    private let underBarView = UnderBarView()
+    
     private let baseStackView = UIStackView().then {
+        $0.axis = .vertical
+    }
+    
+    private let taskSectionStackView = UIStackView().then {
+        $0.axis = .horizontal
         $0.spacing = 15
         $0.distribution = .fillEqually
     }
-
+    
     init() {
         super.init(frame: .zero)
         backgroundColor = .systemGray5
@@ -33,15 +39,22 @@ final class MainView: UIView {
     private func setupSubViews() {
         addSubview(baseStackView)
         
-        baseStackView.addArrangedSubview(todoView)
-        baseStackView.addArrangedSubview(doingView)
-        baseStackView.addArrangedSubview(doneView)
+        taskSectionStackView.addArrangedSubview(todoView)
+        taskSectionStackView.addArrangedSubview(doingView)
+        taskSectionStackView.addArrangedSubview(doneView)
+        
+        baseStackView.addArrangedSubview(taskSectionStackView)
+        baseStackView.addArrangedSubview(underBarView)
     }
     
     private func setupUILayout() {
         baseStackView.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide)
             $0.leading.trailing.bottom.equalToSuperview()
+        }
+        
+        underBarView.snp.makeConstraints {
+            $0.height.equalTo(baseStackView.snp.height).multipliedBy(0.08)
         }
     }
 }

--- a/ProjectManager/ProjectManager/Scene/Main/View/TaskTableViewCell.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/View/TaskTableViewCell.swift
@@ -9,6 +9,7 @@ import UIKit
 import SnapKit
 
 final class TaskTableViewCell: UITableViewCell {
+    
     fileprivate enum Constants {
         static let numberOfLines = 3
     }
@@ -90,7 +91,6 @@ final class TaskTableViewCell: UITableViewCell {
             identifier:
                 Locale.current.identifier
         )
-        
         return dateFormatter.string(from: Date(timeIntervalSince1970: date))
     }
 }

--- a/ProjectManager/ProjectManager/Scene/Main/View/UnderBarView.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/View/UnderBarView.swift
@@ -15,15 +15,19 @@ final class UnderBarView: UIView {
         $0.spacing = 20
     }
     
-    private let undoButton = UIButton().then {
+    private(set) var undoButton = UIButton().then {
         $0.setTitle("Undo", for: .normal)
         $0.setTitleColor(.systemBlue, for: .normal)
+        $0.setTitleColor(.gray, for: .disabled)
+        //$0.isEnabled = false
         $0.titleLabel?.font = .preferredFont(forTextStyle: .title2)
     }
     
-    private let redoButton = UIButton().then {
+    private(set) var redoButton = UIButton().then {
         $0.setTitle("Redo", for: .normal)
         $0.setTitleColor(.systemBlue, for: .normal)
+        $0.setTitleColor(.gray, for: .disabled)
+        //$0.isEnabled = false
         $0.titleLabel?.font = .preferredFont(forTextStyle: .title2)
     }
     
@@ -49,5 +53,6 @@ final class UnderBarView: UIView {
             $0.top.bottom.equalToSuperview()
             $0.trailing.equalToSuperview().inset(10)
         }
+        backgroundColor = .systemBackground
     }
 }

--- a/ProjectManager/ProjectManager/Scene/Main/View/UnderBarView.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/View/UnderBarView.swift
@@ -1,0 +1,53 @@
+//
+//  UnderBarView.swift
+//  ProjectManager
+//
+//  Created by Donnie, Grump on 2022/07/26.
+//
+
+import UIKit
+import SnapKit
+
+final class UnderBarView: UIView {
+    
+    private let baseStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 20
+    }
+    
+    private let undoButton = UIButton().then {
+        $0.setTitle("Undo", for: .normal)
+        $0.setTitleColor(.systemBlue, for: .normal)
+        $0.titleLabel?.font = .preferredFont(forTextStyle: .title2)
+    }
+    
+    private let redoButton = UIButton().then {
+        $0.setTitle("Redo", for: .normal)
+        $0.setTitleColor(.systemBlue, for: .normal)
+        $0.titleLabel?.font = .preferredFont(forTextStyle: .title2)
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupSubViews()
+        setupUILayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupSubViews() {
+        addSubview(baseStackView)
+        
+        baseStackView.addArrangedSubview(undoButton)
+        baseStackView.addArrangedSubview(redoButton)
+    }
+    
+    private func setupUILayout() {
+        baseStackView.snp.makeConstraints {
+            $0.top.bottom.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(10)
+        }
+    }
+}

--- a/ProjectManager/ProjectManager/Scene/Main/ViewController/MainViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/ViewController/MainViewController.swift
@@ -76,6 +76,7 @@ final class MainViewController: UIViewController, UIPopoverPresentationControlle
         bindItemsDeleted()
         bindLongPressGestures()
         bindErrorAlert()
+        bindUndoRedoButtons()
     }
     
     private func cell(
@@ -272,6 +273,20 @@ extension MainViewController {
                 })
                 .disposed(by: disposeBag)
         }
+    }
+    
+    private func bindUndoRedoButtons() {
+        mainView.underBarView.undoButton.rx.tap
+            .subscribe { [weak self] _ in
+                self?.viewModel.undoButtonTapped()
+            }
+            .disposed(by: disposeBag)
+        
+        mainView.underBarView.redoButton.rx.tap
+            .subscribe { [weak self] _ in
+                self?.viewModel.redoButtonTapped()
+            }
+            .disposed(by: disposeBag)
     }
 }
 

--- a/ProjectManager/ProjectManager/Scene/Main/ViewController/MainViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/ViewController/MainViewController.swift
@@ -135,6 +135,11 @@ final class MainViewController: UIViewController, UIPopoverPresentationControlle
         editFormSheet.modalPresentationStyle = .formSheet
         present(editFormSheet, animated: true)
     }
+    
+    private func initializeUndoRedoButtons() {
+        mainView.footerView.undoButton.isEnabled = true
+        mainView.footerView.redoButton.isEnabled = false
+    }
 }
 
 // MARK: - bind Funciton
@@ -278,21 +283,21 @@ extension MainViewController {
     private func bindUndoRedoButtons() {
         viewModel.undoable
             .map({ Bool($0) })
-            .bind(to: mainView.underBarView.undoButton.rx.isEnabled)
+            .bind(to: mainView.footerView.undoButton.rx.isEnabled)
             .disposed(by: disposeBag)
         
         viewModel.redoable
             .map({ Bool($0) })
-            .bind(to: mainView.underBarView.redoButton.rx.isEnabled)
+            .bind(to: mainView.footerView.redoButton.rx.isEnabled)
             .disposed(by: disposeBag)
         
-        mainView.underBarView.undoButton.rx.tap
+        mainView.footerView.undoButton.rx.tap
             .subscribe { [weak self] _ in
                 self?.viewModel.undoButtonTapped()
             }
             .disposed(by: disposeBag)
         
-        mainView.underBarView.redoButton.rx.tap
+        mainView.footerView.redoButton.rx.tap
             .subscribe { [weak self] _ in
                 self?.viewModel.redoButtonTapped()
             }
@@ -303,8 +308,7 @@ extension MainViewController {
 extension MainViewController: DataReloadable {
     func reloadData() {
         viewModel.fetchData()
-        mainView.underBarView.undoButton.isEnabled = true
-        mainView.underBarView.redoButton.isEnabled = false
+        initializeUndoRedoButtons()
     }
 }
 

--- a/ProjectManager/ProjectManager/Scene/Main/ViewController/MainViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/ViewController/MainViewController.swift
@@ -276,6 +276,16 @@ extension MainViewController {
     }
     
     private func bindUndoRedoButtons() {
+        viewModel.undoable
+            .map({ Bool($0) })
+            .bind(to: mainView.underBarView.undoButton.rx.isEnabled)
+            .disposed(by: disposeBag)
+        
+        viewModel.redoable
+            .map({ Bool($0) })
+            .bind(to: mainView.underBarView.redoButton.rx.isEnabled)
+            .disposed(by: disposeBag)
+        
         mainView.underBarView.undoButton.rx.tap
             .subscribe { [weak self] _ in
                 self?.viewModel.undoButtonTapped()
@@ -293,6 +303,7 @@ extension MainViewController {
 extension MainViewController: DataReloadable {
     func reloadData() {
         viewModel.fetchData()
+        mainView.underBarView.undoButton.isEnabled = true
     }
 }
 

--- a/ProjectManager/ProjectManager/Scene/Main/ViewController/MainViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/ViewController/MainViewController.swift
@@ -304,6 +304,7 @@ extension MainViewController: DataReloadable {
     func reloadData() {
         viewModel.fetchData()
         mainView.underBarView.undoButton.isEnabled = true
+        mainView.underBarView.redoButton.isEnabled = false
     }
 }
 

--- a/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
@@ -9,6 +9,7 @@ import Foundation
 import RxRelay
 import RxSwift
 import Network
+import UserNotifications
 
 protocol MainViewModelEvent {
     func cellItemDeleted(at indexPath: IndexPath, taskType: TaskType)
@@ -88,6 +89,10 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
         fetchToDo()
         fetchDoing()
         fetchDone()
+        
+        todos.value.forEach {
+            self.createDeadlineNotification(at: $0)
+        }
     }
     
     private func deleteData(task: Task) {
@@ -203,5 +208,21 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
             undoable.accept(true)
         }
         fetchData()
+    }
+    
+    private func createDeadlineNotification(at task: Task) {
+        let content = UNMutableNotificationContent()
+        content.title = task.title
+        content.body = task.body
+        content.sound = .default
+        
+//        var dateComponents = DateComponents()
+//        dateComponents.calendar = Calendar.current
+//        dateComponents.hour = 9
+        
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 4, repeats: false)
+        let request = UNNotificationRequest(identifier: task.id, content: content, trigger: trigger)
+        
+        UNUserNotificationCenter.current().add(request)
     }
 }

--- a/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
@@ -92,12 +92,20 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
     }
     
     private func deleteData(task: Task) {
-        registerDeleteUndoAction(task: task)
-        let title = task.title
-        let type = task.taskType
+        let capturedTask = Task(
+            title: task.title,
+            body: task.body,
+            date: task.date,
+            taskType: task.taskType,
+            id: task.id
+        )
+        
+        registerDeleteUndoAction(task: capturedTask)
+        let title = capturedTask.title
+        let type = capturedTask.taskType
         
         do {
-            try realmManager.delete(task: task)
+            try realmManager.delete(task: capturedTask)
             sendNotificationForHistory(title, from: type)
             undoable.accept(true)
             redoable.accept(false)
@@ -116,7 +124,7 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
     }
     
     private func registerDeleteUndoAction(task: Task) {
-        let newTask = Task(
+        let capturedTask = Task(
             title: task.title,
             body: task.body,
             date: task.date,
@@ -126,8 +134,8 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
         
         undoManager.registerUndo(withTarget: self) { [weak self] _ in
             do {
-                self?.registerDeleteRedoAction(task: newTask)
-                try self?.realmManager.create(task: newTask)
+                self?.registerDeleteRedoAction(task: capturedTask)
+                try self?.realmManager.create(task: capturedTask)
                 self?.sendNotificationForHistory()
             } catch {
                 self?.error.accept(DatabaseError.createError)
@@ -136,20 +144,20 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
     }
     
     private func registerDeleteRedoAction(task: Task) {
-        let createdTask = Task(
+        let capturedTask = Task(
             title: task.title,
             body: task.body,
             date: task.date,
             taskType: task.taskType,
             id: task.id
         )
-        let title = task.title
-        let type = task.taskType
+        let title = capturedTask.title
+        let type = capturedTask.taskType
         
         undoManager.registerUndo(withTarget: self) { [weak self] _ in
             do {
-                self?.registerDeleteUndoAction(task: createdTask)
-                try self?.realmManager.delete(task: task)
+                self?.registerDeleteUndoAction(task: capturedTask)
+                try self?.realmManager.delete(task: capturedTask)
                 self?.sendNotificationForHistory(title, from: type)
             } catch {
                 self?.error.accept(DatabaseError.createError)

--- a/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
@@ -109,7 +109,11 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
         let content = "Removed '\(title)' from \(type.rawValue)"
         let time = Date().timeIntervalSince1970
         let history: [String: Any] = ["content": content, "time": time]
-        NotificationCenter.default.post(name: NSNotification.Name("History"), object: nil, userInfo: history)
+        NotificationCenter.default.post(name: NSNotification.Name("Push"), object: nil, userInfo: history)
+    }
+    
+    private func sendNotificationForHistory() {
+        NotificationCenter.default.post(name: NSNotification.Name("Pop"), object: nil, userInfo: nil)
     }
         
     private func fetchToDo() {

--- a/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
@@ -67,16 +67,17 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
                 self?.syncronize()
             } else {
                 self?.online.accept(false)
+            }
+            DispatchQueue.main.async {
                 self?.fetchData()
             }
         }
     }
     
     func syncronize() {
-        synchronizeManager.synchronizeDatabase { [weak self] result in
+        synchronizeManager.synchronizeDatabase { result in
             switch result {
             case .success:
-                self?.fetchData()
                 return
             case .failure(let error):
                 print(error.localizedDescription)

--- a/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
@@ -24,7 +24,11 @@ protocol MainViewModelState {
     var redoable: BehaviorRelay<Bool> { get }
 }
 
-final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservable, PopNotificationSendable {
+final class MainViewModel: MainViewModelEvent,
+                            MainViewModelState,
+                            ErrorObservable,
+                            PopNotificationSendable,
+                            PushDeleteNotificationSendable {
     
     var todos: BehaviorRelay<[Task]> = BehaviorRelay(value: AppConstants.defaultTaskArrayValue)
     var doings: BehaviorRelay<[Task]> = BehaviorRelay(value: AppConstants.defaultTaskArrayValue)
@@ -165,13 +169,6 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
         }
     }
     
-    private func sendNotificationForHistory(_ title: String, from type: TaskType) {
-        let content = "Removed '\(title)' from \(type.rawValue)"
-        let time = Date().timeIntervalSince1970
-        let history: [String: Any] = ["content": content, "time": time]
-        NotificationCenter.default.post(name: NSNotification.Name("PushHistory"), object: nil, userInfo: history)
-    }
-        
     private func fetchToDo() {
         let todos = realmManager.fetchTasks(type: .todo)
         setupTaskDeadlineNotification(todos)

--- a/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
@@ -235,8 +235,7 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
         dateComponents.calendar = Calendar.current
         dateComponents.hour = 9
         
-        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 4, repeats: false)
-        //let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: false)
+        let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: false)
         let request =  UNNotificationRequest(identifier: task.id, content: content, trigger: trigger)
         
         UNUserNotificationCenter.current().add(request)

--- a/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
@@ -111,7 +111,6 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
         case .done:
             fetchDone()
         }
-        
     }
     
     private func registerDeleteUndoAction(task: Task) {
@@ -144,9 +143,10 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
         )
         let title = task.title
         let type = task.taskType
+        
         undoManager.registerUndo(withTarget: self) { [weak self] _ in
             do {
-                self?.registerDeleteRedoAction(task: createdTask)
+                self?.registerDeleteUndoAction(task: createdTask)
                 try self?.realmManager.delete(task: task)
                 self?.sendNotificationForHistory(title, from: type)
             } catch {
@@ -182,6 +182,7 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
     }
     
     func undoButtonTapped() {
+        
         undoManager.undo()
         redoable.accept(true)
         if !undoManager.canUndo {

--- a/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
@@ -24,7 +24,7 @@ protocol MainViewModelState {
     var redoable: BehaviorRelay<Bool> { get }
 }
 
-final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservable {
+final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservable, PopNotificationSendable {
     
     var todos: BehaviorRelay<[Task]> = BehaviorRelay(value: AppConstants.defaultTaskArrayValue)
     var doings: BehaviorRelay<[Task]> = BehaviorRelay(value: AppConstants.defaultTaskArrayValue)
@@ -50,7 +50,6 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
         case .done:
             task = dones.value[indexPath.row]
         }
-        
         deleteData(task: task)
     }
     
@@ -161,11 +160,7 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
         let content = "Removed '\(title)' from \(type.rawValue)"
         let time = Date().timeIntervalSince1970
         let history: [String: Any] = ["content": content, "time": time]
-        NotificationCenter.default.post(name: NSNotification.Name("Push"), object: nil, userInfo: history)
-    }
-    
-    private func sendNotificationForHistory() {
-        NotificationCenter.default.post(name: NSNotification.Name("Pop"), object: nil, userInfo: nil)
+        NotificationCenter.default.post(name: NSNotification.Name("PushHistory"), object: nil, userInfo: history)
     }
         
     private func fetchToDo() {
@@ -226,7 +221,7 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
         }
         
         let content = UNMutableNotificationContent()
-        content.title = "오늘까지인 할 일이 있습니다."
+        content.title = "오늘까지인 일정이 있습니다."
         content.body = task.title
         content.subtitle = task.taskType.rawValue
         content.sound = .default

--- a/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
@@ -114,10 +114,11 @@ final class MainViewModel: MainViewModelEvent,
         registerDeleteUndoAction(task: capturedTask)
         let title = capturedTask.title
         let type = capturedTask.taskType
-        
+        let id = capturedTask.id
         do {
             try realmManager.delete(task: capturedTask)
             sendNotificationForHistory(title, from: type)
+            UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [id])
             undoable.accept(true)
             redoable.accept(false)
         } catch {
@@ -164,11 +165,12 @@ final class MainViewModel: MainViewModelEvent,
         )
         let title = capturedTask.title
         let type = capturedTask.taskType
-        
+        let id = capturedTask.id
         undoManager.registerUndo(withTarget: self) { [weak self] _ in
             do {
                 self?.registerDeleteUndoAction(task: capturedTask)
                 try self?.realmManager.delete(task: capturedTask)
+                UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [id])
                 self?.sendNotificationForHistory(title, from: type)
             } catch {
                 self?.error.accept(DatabaseError.createError)

--- a/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
@@ -30,6 +30,13 @@ final class MainViewModel: MainViewModelEvent,
                             PopNotificationSendable,
                             PushDeleteNotificationSendable {
     
+    fileprivate enum Constants {
+        static let monitoringQueue: String = "monitor"
+        static let userNotificationTitle: String = "오늘까지인 일정이 있습니다."
+        static let userNotificationHour: Int = 9
+        static let secondOfDay: Double = 86400
+    }
+    
     var todos: BehaviorRelay<[Task]> = BehaviorRelay(value: AppConstants.defaultTaskArrayValue)
     var doings: BehaviorRelay<[Task]> = BehaviorRelay(value: AppConstants.defaultTaskArrayValue)
     var dones: BehaviorRelay<[Task]> = BehaviorRelay(value: AppConstants.defaultTaskArrayValue)
@@ -62,7 +69,7 @@ final class MainViewModel: MainViewModelEvent,
     }
     
     private func startMonitoring() {
-        let monitoringQueue = DispatchQueue(label: "network", attributes: .concurrent)
+        let monitoringQueue = DispatchQueue(label: Constants.monitoringQueue, attributes: .concurrent)
         monitor.start(queue: monitoringQueue)
         monitor.pathUpdateHandler = { [weak self] path in
             if path.status == .satisfied {
@@ -227,14 +234,14 @@ final class MainViewModel: MainViewModelEvent,
         }
         
         let content = UNMutableNotificationContent()
-        content.title = "오늘까지인 일정이 있습니다."
+        content.title = Constants.userNotificationTitle
         content.body = task.title
         content.subtitle = task.taskType.rawValue
         content.sound = .default
         
         var dateComponents = DateComponents()
         dateComponents.calendar = Calendar.current
-        dateComponents.hour = 9
+        dateComponents.hour = Constants.userNotificationHour
         
         let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: false)
         let request =  UNNotificationRequest(identifier: task.id, content: content, trigger: trigger)
@@ -244,7 +251,7 @@ final class MainViewModel: MainViewModelEvent,
     
     private func todayIsDeadline(of task: Task) -> Bool {
         let today = Calendar.current.startOfDay(for: Date()).timeIntervalSince1970
-        let tomorrow = today + 86400
+        let tomorrow = today + Constants.secondOfDay
         
         if task.date > today, task.date < tomorrow {
             return true

--- a/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
@@ -100,6 +100,7 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
             try realmManager.delete(task: task)
             sendNotificationForHistory(title, from: type)
             undoable.accept(true)
+            redoable.accept(false)
         } catch {
             self.error.accept(DatabaseError.deleteError)
         }

--- a/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
@@ -99,7 +99,6 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
         registerDeleteUndoAction(task: task)
         let title = task.title
         let type = task.taskType
-                
         do {
             try realmManager.delete(task: task)
             sendNotificationForHistory(title, from: type)
@@ -187,7 +186,6 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
     }
     
     func undoButtonTapped() {
-        
         undoManager.undo()
         redoable.accept(true)
         if !undoManager.canUndo {

--- a/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
@@ -210,24 +210,18 @@ final class MainViewModel: MainViewModelEvent,
     
     func undoButtonTapped() {
         undoManager.undo()
-        redoable.accept(true)
-        if !undoManager.canUndo {
-            undoable.accept(false)
-        }
+        acceptUndoRedoState()
         fetchData()
     }
     
     func redoButtonTapped() {
         undoManager.redo()
-        if undoManager.canRedo {
-            redoable.accept(true)
-        } else {
-            redoable.accept(false)
-        }
-        
-        if undoManager.canUndo {
-            undoable.accept(true)
-        }
+        acceptUndoRedoState()
         fetchData()
+    }
+    
+    private func acceptUndoRedoState() {
+        undoable.accept(undoManager.canUndo)
+        redoable.accept(undoManager.canRedo)
     }
 }

--- a/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/ViewModel/MainViewModel.swift
@@ -86,16 +86,25 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
     }
     
     private func deleteData(task: Task) {
-        let newTask: Task = Task(title: task.title, body: task.body, date: task.date, taskType: task.taskType, id: task.id)
+        
+        let newTask = Task(
+            title: task.title,
+            body: task.body,
+            date: task.date,
+            taskType: task.taskType,
+            id: task.id
+        )
+        
         undoManager.registerUndo(withTarget: self) { [weak self] _ in
             do {
                 try self?.realmManager.create(task: newTask)
-                
                 self?.sendNotificationForHistory()
             } catch {
                 self?.error.accept(DatabaseError.createError)
             }
         }
+        
+        
         
         let title = task.title
         let type = task.taskType
@@ -150,7 +159,7 @@ final class MainViewModel: MainViewModelEvent, MainViewModelState, ErrorObservab
     }
     
     func redoButtonTapped() {
-        print("# Redo")
         undoManager.redo()
+        fetchData()
     }
 }

--- a/ProjectManager/ProjectManager/Scene/Popover/ViewModel/PopoverViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Popover/ViewModel/PopoverViewModel.swift
@@ -27,6 +27,7 @@ final class PopoverViewModel: PopoverViewModelEvent,
     var error: PublishRelay<DatabaseError> = .init()
     private let undoManager = AppDelegate.undoManager
     private let realmManager = RealmManager()
+    private let userNotificationManager = UserNotificationManager()
     
     func moveButtonTapped(_ task: Task, to taskType: TaskType) {
         changeTaskType(task, taskType: taskType)
@@ -42,6 +43,7 @@ final class PopoverViewModel: PopoverViewModelEvent,
             id: task.id
         )
         registerChangeUndoAction(task: capturedChangedTask, targetType: beforeType)
+        userNotificationManager.adjustUserNotificationAboutTypeChange(of: capturedChangedTask)
         do {
             try realmManager.change(task: task, targetType: taskType)
             sendNotificationForHistory(task.title, from: beforeType, to: task.taskType)
@@ -62,6 +64,7 @@ final class PopoverViewModel: PopoverViewModelEvent,
         )
         undoManager.registerUndo(withTarget: self) { [weak self] _ in
             self?.registerChangeRedoAction(task: capturedChangedTask, targetType: beforeType)
+            self?.userNotificationManager.adjustUserNotificationAboutTypeChange(of: capturedChangedTask)
             do {
                 try self?.realmManager.change(task: task, targetType: targetType)
                 self?.sendNotificationForHistory()
@@ -89,6 +92,7 @@ final class PopoverViewModel: PopoverViewModelEvent,
         )
         undoManager.registerUndo(withTarget: self) { [weak self] _ in
             self?.registerChangeUndoAction(task: capturedChangedTask, targetType: beforeTask)
+            self?.userNotificationManager.adjustUserNotificationAboutTypeChange(of: capturedChangedTask)
             do {
                 try self?.realmManager.change(task: task, targetType: targetType)
                 self?.sendNotificationForHistory(

--- a/ProjectManager/ProjectManager/Scene/Popover/ViewModel/PopoverViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Popover/ViewModel/PopoverViewModel.swift
@@ -29,8 +29,17 @@ final class PopoverViewModel: PopoverViewModelEvent, PopoverViewModelState, Erro
     }
 
     private func changeTaskType(_ task: Task, taskType: TaskType) {
+        
         let beforeType = task.taskType
-        let temp = Task(title: task.title, body: task.body, date: task.date, taskType: task.taskType, id: task.id)
+        
+        let temp = Task(
+            title: task.title,
+            body: task.body,
+            date: task.date,
+            taskType: task.taskType,
+            id: task.id
+        )
+        
         registerChangeUndoAction(task: temp, taskType: taskType)
         
         do {

--- a/ProjectManager/ProjectManager/Scene/Popover/ViewModel/PopoverViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Popover/ViewModel/PopoverViewModel.swift
@@ -30,8 +30,8 @@ final class PopoverViewModel: PopoverViewModelEvent, PopoverViewModelState, Erro
 
     private func changeTaskType(_ task: Task, taskType: TaskType) {
         let beforeType = task.taskType
-
-        registerChangeUndoAction(task: task, taskType: taskType)
+        let temp = Task(title: task.title, body: task.body, date: task.date, taskType: task.taskType, id: task.id)
+        registerChangeUndoAction(task: temp, taskType: taskType)
         
         do {
             try realmManager.change(task: task, targetType: taskType)
@@ -65,11 +65,12 @@ final class PopoverViewModel: PopoverViewModelEvent, PopoverViewModelState, Erro
     
     private func registerChangeRedoAction(task: Task, taskType: TaskType) {
         undoManager.registerUndo(withTarget: self) { [weak self] _ in
-            let afterType = task.taskType
+            let temp = Task(title: task.title, body: task.body, date: task.date, taskType: task.taskType, id: task.id)
+            let afterType = temp.taskType
             do {
-                self?.registerChangeUndoAction(task: task, taskType: taskType)
-                try self?.realmManager.change(task: task, targetType: taskType)
-                self?.sendNotificationForHistory(task.title, from: afterType, to: task.taskType)
+                self?.registerChangeUndoAction(task: temp, taskType: taskType)
+                try self?.realmManager.change(task: temp, targetType: taskType)
+                self?.sendNotificationForHistory(temp.title, from: afterType, to: temp.taskType)
             } catch {
                 self?.error.accept(DatabaseError.changeError)
             }

--- a/ProjectManager/ProjectManager/Scene/Popover/ViewModel/PopoverViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Popover/ViewModel/PopoverViewModel.swift
@@ -44,7 +44,7 @@ final class PopoverViewModel: PopoverViewModelEvent, PopoverViewModelState, Erro
     }
     
     private func registerChangeUndoAction(task: Task, taskType: TaskType) {
-        
+        let beforeType = task.taskType
         let movedTask = Task(
             title: task.title,
             body: task.body,
@@ -52,9 +52,6 @@ final class PopoverViewModel: PopoverViewModelEvent, PopoverViewModelState, Erro
             taskType: taskType,
             id: task.id
         )
-        
-        let beforeType = task.taskType
-
         undoManager.registerUndo(withTarget: self) { [weak self] _ in
             do {
                 self?.registerChangeRedoAction(task: task, taskType: taskType)
@@ -67,13 +64,12 @@ final class PopoverViewModel: PopoverViewModelEvent, PopoverViewModelState, Erro
     }
     
     private func registerChangeRedoAction(task: Task, taskType: TaskType) {
-        let beforeType = task.taskType
-
         undoManager.registerUndo(withTarget: self) { [weak self] _ in
+            let afterType = task.taskType
             do {
                 self?.registerChangeUndoAction(task: task, taskType: taskType)
                 try self?.realmManager.change(task: task, targetType: taskType)
-                self?.sendNotificationForHistory(task.title, from: beforeType, to: task.taskType)
+                self?.sendNotificationForHistory(task.title, from: afterType, to: task.taskType)
             } catch {
                 self?.error.accept(DatabaseError.changeError)
             }

--- a/ProjectManager/ProjectManager/Scene/Popover/ViewModel/PopoverViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Popover/ViewModel/PopoverViewModel.swift
@@ -45,6 +45,6 @@ final class PopoverViewModel: PopoverViewModelEvent, PopoverViewModelState, Erro
         let content = "Moved '\(title)' from \(beforeType.rawValue) to \(afterType.rawValue)"
         let time = Date().timeIntervalSince1970
         let history: [String: Any] = ["content": content, "time": time]
-        NotificationCenter.default.post(name: NSNotification.Name("History"), object: nil, userInfo: history)
+        NotificationCenter.default.post(name: NSNotification.Name("Pop"), object: nil, userInfo: history)
     }
 }

--- a/ProjectManager/ProjectManager/SceneDelegate.swift
+++ b/ProjectManager/ProjectManager/SceneDelegate.swift
@@ -33,11 +33,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, UNUserNotificationCente
         window?.rootViewController = splitViewController
         window?.makeKeyAndVisible()
         
+        configureLocalNotification(viewController: mainViewController)
+    }
+    
+    private func configureLocalNotification(viewController: UIViewController) {
         current.delegate = self
         current.requestAuthorization(options: [.sound, .alert, .badge]) { isAllowed, _ in
             if !isAllowed {
                 DispatchQueue.main.async {
-                    self.showAlert(viewController: mainViewController) { _ in
+                    self.showAlert(viewController: viewController) { _ in
                         self.showSettingURL()
                     }
                 }

--- a/ProjectManager/ProjectManager/SceneDelegate.swift
+++ b/ProjectManager/ProjectManager/SceneDelegate.swift
@@ -6,10 +6,11 @@
 
 import UIKit
 
-class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+class SceneDelegate: UIResponder, UIWindowSceneDelegate, UNUserNotificationCenterDelegate {
     
     var window: UIWindow?
-    
+    private let current = UNUserNotificationCenter.current()
+
     func scene(
         _ scene: UIScene,
         willConnectTo session: UISceneSession,
@@ -31,5 +32,36 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window?.rootViewController = splitViewController
         window?.makeKeyAndVisible()
+        
+        current.delegate = self
+        current.requestAuthorization(options: [.sound, .alert, .badge]) { isAllowed, _ in
+            if !isAllowed {
+                DispatchQueue.main.async {
+                    self.showAlert(viewController: mainViewController) { _ in
+                        self.showSettingURL()
+                    }
+                }
+            }
+        }
+    }
+    
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions
+        ) -> Void) {
+        completionHandler([.sound, .banner, .badge])
+    }
+    
+    private func showSettingURL() {
+        guard let settingURL = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(settingURL)
+    }
+    
+    private func showAlert(viewController: UIViewController, handler: @escaping ((UIAlertAction) -> Void)) {
+        let alert = UIAlertController(title: "알림 권한", message: "서비스를 이용하시려면 알림 권한을 허용해주세요", preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "확인", style: .default, handler: handler)
+        alert.addAction(okAction)
+        viewController.present(alert, animated: true)
     }
 }

--- a/ProjectManager/ProjectManager/SceneDelegate.swift
+++ b/ProjectManager/ProjectManager/SceneDelegate.swift
@@ -63,8 +63,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, UNUserNotificationCente
     }
     
     private func showAlert(viewController: UIViewController, handler: @escaping ((UIAlertAction) -> Void)) {
-        let alert = UIAlertController(title: "알림 권한", message: "서비스를 이용하시려면 알림 권한을 허용해주세요", preferredStyle: .alert)
-        let okAction = UIAlertAction(title: "확인", style: .default, handler: handler)
+        let alert = UIAlertController(
+            title: AppConstants.notificationPermissionAlertTitle,
+            message: AppConstants.notificationPermissionAlertMessage,
+            preferredStyle: .alert
+        )
+        let okAction = UIAlertAction(
+            title: AppConstants.okActionTitle,
+            style: .default,
+            handler: handler
+        )
         alert.addAction(okAction)
         viewController.present(alert, animated: true)
     }

--- a/ProjectManager/ProjectManager/Utils/AppConstants.swift
+++ b/ProjectManager/ProjectManager/Utils/AppConstants.swift
@@ -11,4 +11,12 @@ enum AppConstants {
     static let defaultStringValue: String = ""
     static let defaultDoubleValue: Double = .zero
     static let defaultTaskArrayValue: [Task] = []
+    static let pushHistoryNotificationName: String = "PushHistory"
+    static let popHistoryNotificationName: String = "PopHistory"
+    static let historyContentKey: String = "content"
+    static let historyTimeKey: String = "time"
+    static let errorAlertTitle: String = "오류"
+    static let okActionTitle: String = "확인"
+    static let notificationPermissionAlertTitle: String = "알림 권한"
+    static let notificationPermissionAlertMessage: String = "서비스를 이용하시려면 알림 권한을 허용해주세요"
 }

--- a/ProjectManager/ProjectManager/Utils/Extension/UIViewController+extension.swift
+++ b/ProjectManager/ProjectManager/Utils/Extension/UIViewController+extension.swift
@@ -9,8 +9,15 @@ import UIKit
 
 extension UIViewController {
     func showAlert(message: String) {
-        let alertController = UIAlertController(title: "오류", message: message, preferredStyle: .alert)
-        let okAction = UIAlertAction(title: "확인", style: .default)
+        let alertController = UIAlertController(
+            title: AppConstants.errorAlertTitle,
+            message: message,
+            preferredStyle: .alert
+        )
+        let okAction = UIAlertAction(
+            title: AppConstants.okActionTitle,
+            style: .default
+        )
         alertController.addAction(okAction)
         self.present(alertController, animated: true)
     }

--- a/ProjectManager/ProjectManager/Utils/Protocol/PopNotificationSendable.swift
+++ b/ProjectManager/ProjectManager/Utils/Protocol/PopNotificationSendable.swift
@@ -1,0 +1,18 @@
+//
+//  PopNotificationSendable.swift
+//  ProjectManager
+//
+//  Created by Donnie, Grumpy on 2022/07/27.
+//
+
+import Foundation
+
+protocol PopNotificationSendable {
+    func sendNotificationForHistory()
+}
+
+extension PopNotificationSendable {
+    func sendNotificationForHistory() {
+        NotificationCenter.default.post(name: NSNotification.Name("PopHistory"), object: nil, userInfo: nil)
+    }
+}

--- a/ProjectManager/ProjectManager/Utils/Protocol/PopNotificationSendable.swift
+++ b/ProjectManager/ProjectManager/Utils/Protocol/PopNotificationSendable.swift
@@ -13,6 +13,10 @@ protocol PopNotificationSendable {
 
 extension PopNotificationSendable {
     func sendNotificationForHistory() {
-        NotificationCenter.default.post(name: NSNotification.Name("PopHistory"), object: nil, userInfo: nil)
+        NotificationCenter.default.post(
+            name: NSNotification.Name(AppConstants.popHistoryNotificationName),
+            object: nil,
+            userInfo: nil
+        )
     }
 }

--- a/ProjectManager/ProjectManager/Utils/Protocol/PushAddNotificationSendable.swift
+++ b/ProjectManager/ProjectManager/Utils/Protocol/PushAddNotificationSendable.swift
@@ -1,0 +1,21 @@
+//
+//  PushAddNotificationSendable.swift
+//  ProjectManager
+//
+//  Created by Donnie, Grumpy on 2022/07/28.
+//
+
+import Foundation
+
+protocol PushAddNotificationSendable {
+    func sendNotificationForHistory()
+}
+
+extension PushAddNotificationSendable {
+    func sendNotificationForHistory(_ title: String) {
+        let content = "Added '\(title)'."
+        let time = Date().timeIntervalSince1970
+        let history: [String: Any] = ["content": content, "time": time]
+        NotificationCenter.default.post(name: NSNotification.Name("PushHistory"), object: nil, userInfo: history)
+    }
+}

--- a/ProjectManager/ProjectManager/Utils/Protocol/PushAddNotificationSendable.swift
+++ b/ProjectManager/ProjectManager/Utils/Protocol/PushAddNotificationSendable.swift
@@ -15,7 +15,11 @@ extension PushAddNotificationSendable {
     func sendNotificationForHistory(_ title: String) {
         let content = "Added '\(title)'."
         let time = Date().timeIntervalSince1970
-        let history: [String: Any] = ["content": content, "time": time]
-        NotificationCenter.default.post(name: NSNotification.Name("PushHistory"), object: nil, userInfo: history)
+        let history: [String: Any] = [AppConstants.historyContentKey: content, AppConstants.historyTimeKey: time]
+        NotificationCenter.default.post(
+            name: NSNotification.Name(AppConstants.pushHistoryNotificationName),
+            object: nil,
+            userInfo: history
+        )
     }
 }

--- a/ProjectManager/ProjectManager/Utils/Protocol/PushDeleteNotificationSendable.swift
+++ b/ProjectManager/ProjectManager/Utils/Protocol/PushDeleteNotificationSendable.swift
@@ -1,0 +1,21 @@
+//
+//  PushDeleteNotificationSendable.swift
+//  ProjectManager
+//
+//  Created by Donnie, Grumpy on 2022/07/28.
+//
+
+import Foundation
+
+protocol PushDeleteNotificationSendable {
+    func sendNotificationForHistory()
+}
+
+extension PushDeleteNotificationSendable {
+    func sendNotificationForHistory(_ title: String, from type: TaskType) {
+        let content = "Removed '\(title)' from \(type.rawValue)"
+        let time = Date().timeIntervalSince1970
+        let history: [String: Any] = ["content": content, "time": time]
+        NotificationCenter.default.post(name: NSNotification.Name("PushHistory"), object: nil, userInfo: history)
+    }
+}

--- a/ProjectManager/ProjectManager/Utils/Protocol/PushDeleteNotificationSendable.swift
+++ b/ProjectManager/ProjectManager/Utils/Protocol/PushDeleteNotificationSendable.swift
@@ -15,7 +15,11 @@ extension PushDeleteNotificationSendable {
     func sendNotificationForHistory(_ title: String, from type: TaskType) {
         let content = "Removed '\(title)' from \(type.rawValue)"
         let time = Date().timeIntervalSince1970
-        let history: [String: Any] = ["content": content, "time": time]
-        NotificationCenter.default.post(name: NSNotification.Name("PushHistory"), object: nil, userInfo: history)
+        let history: [String: Any] = [AppConstants.historyContentKey: content, AppConstants.historyTimeKey: time]
+        NotificationCenter.default.post(
+            name: NSNotification.Name(AppConstants.pushHistoryNotificationName),
+            object: nil,
+            userInfo: history
+        )
     }
 }

--- a/ProjectManager/ProjectManager/Utils/Protocol/PushMovingNotificationSendable.swift
+++ b/ProjectManager/ProjectManager/Utils/Protocol/PushMovingNotificationSendable.swift
@@ -1,0 +1,21 @@
+//
+//  PushNotificationSendable.swift
+//  ProjectManager
+//
+//  Created by Donnie, Grumpy on 2022/07/28.
+//
+
+import Foundation
+
+protocol PushMovingNotificationSendable {
+    func sendNotificationForHistory()
+}
+
+extension PushMovingNotificationSendable {
+    func sendNotificationForHistory(_ title: String, from beforeType: TaskType, to afterType: TaskType) {
+        let content = "Moved '\(title)' from \(beforeType.rawValue) to \(afterType.rawValue)"
+        let time = Date().timeIntervalSince1970
+        let history: [String: Any] = ["content": content, "time": time]
+        NotificationCenter.default.post(name: NSNotification.Name("PushHistory"), object: nil, userInfo: history)
+    }
+}

--- a/ProjectManager/ProjectManager/Utils/Protocol/PushMovingNotificationSendable.swift
+++ b/ProjectManager/ProjectManager/Utils/Protocol/PushMovingNotificationSendable.swift
@@ -15,7 +15,11 @@ extension PushMovingNotificationSendable {
     func sendNotificationForHistory(_ title: String, from beforeType: TaskType, to afterType: TaskType) {
         let content = "Moved '\(title)' from \(beforeType.rawValue) to \(afterType.rawValue)"
         let time = Date().timeIntervalSince1970
-        let history: [String: Any] = ["content": content, "time": time]
-        NotificationCenter.default.post(name: NSNotification.Name("PushHistory"), object: nil, userInfo: history)
+        let history: [String: Any] = [AppConstants.historyContentKey: content, AppConstants.historyTimeKey: time]
+        NotificationCenter.default.post(
+            name: NSNotification.Name(AppConstants.pushHistoryNotificationName),
+            object: nil,
+            userInfo: history
+        )
     }
 }

--- a/ProjectManager/ProjectManager/Utils/RealmManager.swift
+++ b/ProjectManager/ProjectManager/Utils/RealmManager.swift
@@ -6,6 +6,7 @@
 //
 
 import RealmSwift
+import UserNotifications
 
 struct RealmManager {
     private let realmInstance = try? Realm()
@@ -44,8 +45,10 @@ struct RealmManager {
     }
     
     func delete(task: Task) throws {
+        
         do {
             try realmInstance?.write {
+                UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [task.id])
                 realmInstance?.delete(task)
             }
         } catch {

--- a/ProjectManager/ProjectManager/Utils/RealmManager.swift
+++ b/ProjectManager/ProjectManager/Utils/RealmManager.swift
@@ -45,7 +45,6 @@ struct RealmManager {
     }
     
     func delete(task: Task) throws {
-        
         do {
             try realmInstance?.write {
                 UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [task.id])

--- a/ProjectManager/ProjectManager/Utils/RealmManager.swift
+++ b/ProjectManager/ProjectManager/Utils/RealmManager.swift
@@ -52,7 +52,6 @@ struct RealmManager {
                 }
                 guard let tasks = result else { return }
                 if let queriedTask = tasks.filter({ $0 == $0 }).first {
-                    UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [task.id])
                     realmInstance?.delete(queriedTask)
                 }
             }

--- a/ProjectManager/ProjectManager/Utils/RealmManager.swift
+++ b/ProjectManager/ProjectManager/Utils/RealmManager.swift
@@ -47,8 +47,14 @@ struct RealmManager {
     func delete(task: Task) throws {
         do {
             try realmInstance?.write {
-                UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [task.id])
-                realmInstance?.delete(task)
+                let result = realmInstance?.objects(Task.self).where {
+                    $0.id == task.id
+                }
+                guard let tasks = result else { return }
+                if let queriedTask = tasks.filter({ $0 == $0 }).first {
+                    UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [task.id])
+                    realmInstance?.delete(queriedTask)
+                }
             }
         } catch {
             throw DatabaseError.deleteError

--- a/ProjectManager/ProjectManager/Utils/UserNotificationManager.swift
+++ b/ProjectManager/ProjectManager/Utils/UserNotificationManager.swift
@@ -1,0 +1,71 @@
+//
+//  UserNotificationManager.swift
+//  ProjectManager
+//
+//  Created by Donnie, Grumpy on 2022/07/29.
+//
+
+import Foundation
+import UserNotifications
+
+struct UserNotificationManager {
+    
+    fileprivate enum Constants {
+        static let secondsOfDay: Double = 86400
+        static let userNotificationTitle: String = "오늘까지인 일정이 있습니다."
+        static let userNotificationHour: Int = 9
+    }
+    
+    func addUserNotification(of task: Task) {
+        guard todayIsDeadline(of: task) else {
+            return
+        }
+        
+        let content = UNMutableNotificationContent()
+        content.title = Constants.userNotificationTitle
+        content.body = task.title
+        content.subtitle = task.taskType.rawValue
+        content.sound = .default
+        
+        var dateComponents = DateComponents()
+        dateComponents.calendar = Calendar.current
+        dateComponents.hour = Constants.userNotificationHour
+        
+        let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: false)
+        let request =  UNNotificationRequest(identifier: task.id, content: content, trigger: trigger)
+        
+        UNUserNotificationCenter.current().add(request)
+    }
+    
+    func removeUserNotification(of task: Task) {
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [task.id])
+    }
+    
+    func removeUserNotifications(of tasks: [Task]) {
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: tasks.map { $0.id })
+    }
+    
+    private func todayIsDeadline(of task: Task) -> Bool {
+        let today = Calendar.current.startOfDay(for: Date()).timeIntervalSince1970
+        let tomorrow = today + Constants.secondsOfDay
+        
+        if task.date > today, task.date < tomorrow {
+            return true
+        }
+        return false
+    }
+    
+    func adjustUserNotificationAboutTypeChange(of task: Task) {
+        if task.taskType == .done {
+            removeUserNotification(of: task)
+        } else {
+            addUserNotification(of: task)
+        }
+    }
+    
+    func adjustUserNotificationAboutModify(of task: Task) {
+        if !todayIsDeadline(of: task) {
+            removeUserNotification(of: task)
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@
 - [STEP 3](#step-3)
     - [STEP 3 진행과정](#-step-3-진행과정)
     - [STEP 3 고민한점 및 해결한 부분](#-step-3-고민한-점-및-해결한-부분)
-    - [STEP 3 조언을 얻고 싶은 부분](#-step-3-조언을-얻고-싶은-부분)
-
+- [STEP 4](#step-4)
+    - [STEP 4 진행과정](#-step-4-진행과정)
+    - [STEP 4 고민한점 및 해결한 부분](#-step-4-고민한-점-및-해결한-부분)
+    - [STEP 4 해결하지 못한 부분](#-step-4-해결하지-못한-부분)
 <br>
 
 ## 🔎 프로젝트 소개
@@ -48,7 +50,32 @@
 
 |변경 내역 확인하기|
 |:---:|
-|<img src="https://user-images.githubusercontent.com/63997044/180429788-c3a2014c-e127-4021-bceb-9b6b2179c354.png" width="80%">|
+|<img src="https://user-images.githubusercontent.com/63997044/180429788-c3a2014c-e127-4021-bceb-9b6b2179c354.png" width="60%">|
+
+### 마감일 오전 9시에 로컬 노티피케이션으로 마감일을 알립니다
+|화면 녹화 기준(28일)인 일정만 알림이 옵니다.|
+|:---:|
+|<img width="60%" alt="스크린샷 2022-07-22 오후 8 29 43" src="https://user-images.githubusercontent.com/74251593/181467038-0ada2c74-c857-4db5-bcac-3a924be85d7e.gif">|
+
+### 마감일이 변경되면 알림의 날짜를 변경합니다
+|마감일이 지난 일정은 알림이 오지 않습니다.|마감일이 변경되면 알림의 날짜가 변경됩니다.|
+|:---:|:---:|
+|<img width="100%" alt="스크린샷 2022-07-22 오후 8 29 43" src="https://user-images.githubusercontent.com/74251593/181468162-7341d7a9-03d3-487f-967d-4151f130b1b6.gif">|<img src="https://user-images.githubusercontent.com/74251593/181469495-fea35ccf-bdc9-4de4-890d-993a8b380aae.gif" width="100%">|
+
+### 할일을 완료하면 설정해 두었던 알림을 해제합니다
+|DONE으로 옮겨진 할일은 알림을 띄우지 않습니다.|
+|:---:|
+|<img width="60%" alt="스크린샷 2022-07-22 오후 8 29 43" src="https://user-images.githubusercontent.com/63997044/181471662-80adebbc-5fcd-48c6-97cd-44e5e0e5e130.gif">|
+
+### 화면 하단의 버튼을 통해 되돌리기 기능을 수행할 수 있습니다
+|생성 -> 이동 -> 이동 -> 히스토리 확인 -> Undo -> Undo -> Undo -> 히스토리 확인|
+|:---:|
+|<img width="60%" alt="스크린샷 2022-07-22 오후 8 29 43" src="https://user-images.githubusercontent.com/74251593/181463178-cac5921a-f479-437e-bf89-13e06ac660f4.gif">|
+
+### 수행할 내용이 없으면 버튼을 비활성화 합니다
+|`Undo`, `Redo` 버튼 활성화/비활성화|
+|:---:|
+|<img width="100%" alt="스크린샷 2022-07-22 오후 8 29 43" src="https://user-images.githubusercontent.com/74251593/181464180-0872a4ce-eb55-4313-afb6-71943dd9ac55.gif">|
 
 <br>
 
@@ -77,7 +104,11 @@
 |22.07.20(수)|STEP1 진행|
 |22.07.21(목)|STEP1 진행|
 |22.07.22(금)|STEP1 PR, README 작성|
-
+|22.07.25(월)|STEP2(4-1) 진행|
+|22.07.26(화)|STEP2(4-2) 진행|
+|22.07.27(수)|STEP2(4-2, 4-3) 진행|
+|22.07.28(목)|STEP2(4-3) 진행|
+|22.07.29(금)|README 작성|
 <br>
 
 ## 👀 PR
@@ -87,6 +118,7 @@
 
 프로젝트 매니저 II
 - [STEP 1](https://github.com/yagom-academy/ios-project-manager/pull/160)
+- [STEP 2](https://github.com/yagom-academy/ios-project-manager/pull/166)
 <br>
 
 ## 🛠 개발환경 및 라이브러리
@@ -111,6 +143,8 @@
 - NWPathMonitor
 - UISplitViewController
 - NotificationCenter
+- UndoManager
+- UserNotification
 
 <br>
 
@@ -316,6 +350,8 @@ private func bindErrorAlert() {
     - 변경 이력(History) 기능 구현
     - 소스 코드 리팩토링
 
+<br>
+
 ## 🤔 STEP 3 고민한 점 및 해결한 부분
 ### 1. `History`이력을 어떤 `UI/UX`로 보여야 할지 고민하였습니다.
 <img src="https://user-images.githubusercontent.com/74251593/180429093-f262a451-4f03-4fa4-9937-a22ad70afc08.png" width="80%"><br>
@@ -412,6 +448,118 @@ viewModel.network
     .disposed(by: disposeBag)
 ```
 - 현재 그 내용이 위 코드로 구현되어 있는데 `ViewModel`의 상태값 변화를 `ViewController`가 감지하여 다시 `ViewModel`의 메서드를 실행시킨다는 것이 부자연스럽게 느껴집니다. 위의 코드를 어떻게 개선할 수 있을까요?
+
+<br>
+
+## [STEP 4]
+## ⏳ STEP 4 진행과정
+- **[STEP 4-1]**
+    - Undo, Redo 기능 구현
+- **[STEP 4-2]**
+    - UserNotification 기능 구현
+- **[STEP 4-3]**
+    - 소스 코드 리팩토링
+    - 버그 수정
+
+<br>
+
+## 🤔 STEP 4 고민한 점 및 해결한 부분
+### 1. Undo/Redo Action을 등록하는 방법
+#### 주요논리구조
+1. 생성, 이동, 삭제 등 이벤트가 발생, `Undo`이벤트를 등록 및 저장하는 메서드 호출
+2. `registerUndo`에, `Undo`시의 이벤트 저장과 `Redo`이벤트를 등록하는 메서드 호출, `Undo`버튼 활성화
+3. `Undo`버튼 클릭시 `registerUndo`에 등록 및 저장된 `Undo`이벤트 실행(생성, 이동, 삭제 전으로 변경)
+4. `Redo`버튼 클릭시 `registerUndo`에 등록 및 저장된 `Redo`이벤트 실행(생성, 이동, 삭제 후로 변경)
+
+위와 같은 논리를 바탕으로 `Undo`/`Redo` 기능을 구현해 보았습니다.
+
+<br>
+
+### 2. UserNotification 생성
+#### 현재 구현한 `UserNotification` 생성 방식은 다음과 같습니다.
+- ~~`fetchTodo()`, `fetchDoing()`, `fetchDone()` 호출 시 등록되어 있는 알림을 모두 제거합니다.~~
+- ~~알림을 제거한 후 `identifier`를 `task.id`로 오늘 날짜에 해당하는 알림을 생성합니다.~~
+- ~~수정, 삭제, 이동이 발생하는 경우 `fetchData()`를 통해 알림을 제거하고 다시 생성합니다.~~
+#### 할일을 완료하면 설정해 두었던 알림을 해제합니다
+- ~~할일을 완료하면 `DONE`으로 항목이 이동하는 상황이라고 생각하였습니다.~~
+- ~~`DONE`에 해당하는 데이터(`MainViewModel.dones`)는 알림을 제거만 하고 생성하지 않습니다.~~
+#### 오늘 날짜에 해당하는 알림을 생성하는 이유
+- 요구사항에 `마감일이 변경되면 알림의 날짜를 변경합니다`라는 문장이 있었으나 마감일이 오늘이 아닌 항목에 대해서는 당장 알림을 생성할 필요가 없다고 판단해서 오늘이 마감일인 항목들만 알림을 생성하도록 구현하였습니다.
+
+#### 피드백을 받아 변경된 알림 관리 방식
+- 앱 실행 시 `TODO`, `DOING`의 항목들 중 마감일이 오늘 날짜인 항목에 대한 알림을 생성합니다.
+- 항목 추가 시 `UserNotificationManager`의 `addUserNotification` 메서드에 의해 새로운 알림을 생성합니다.
+- 항목 삭제 시 `UserNotificationManager`의 `removeUserNotification` 메서드에 의해 새로운 알림을 생성합니다.
+- 마감일 변경 시 `UserNotificationManager`의 `adjustUserNotificationAboutModify` 메서드를 호출합니다. 마감일이 오늘이 아니라면 알림을 제거합니다.
+- 항목 이동 시 `UserNotificationManager`의 `adjustUserNotificationAboutTypeChange` 메서드를 호출합니다. 옮겨진 타입이 `TODO`나 `DOING`이라면 알림을 업데이트하고 `DONE`이라면 알림을 제거합니다.
+<br>
+
+### 3. Undo/Redo 실행 시 Realm Object Access
+🙏 공식 문서에 나와있는 내용을 통해 이해한 내용이 아니라 Trouble Shooting으로 인해 이해한 내용이므로 틀릴 수도 있습니다. 혹시 틀린 내용이 있다면 정정 부탁드립니다!
+- `Undo`/`Redo` 동작을 사용하다보면 필연적으로 `Realm Object`에 접근해야 합니다. `Undo`/`Redo` 동작 중에 항목을 삭제하는 `action`이 있을 경우 다음 에러들을 볼 수 있었습니다.
+    - `"Object has been deleted or invalidated"`  
+    - `"Can only delete an object from the Realm it belongs to."`
+- `Realm`의 `delete`를 통해 `object`를 삭제하면 `invalidated`상태가 됩니다. `undoManager.registerUndo()`에서 클로저를 캡처하고 사용할 때 `task`에 대한 값들이 필요한데 이때 이미 삭제된 `task`에 접근이 발생하기 때문인 것으로 보입니다.
+- 또한 Realm에서 `Create`를 제외한`Delete` 등 쓰기 작업에서는 이미 저장되어 있는 Realm Object만 사용 가능하다는 내용으로 파악했습니다. 
+- 즉 fetch를 통해 가져온 `task`와 `let copiedTask = Task(title: task.title ..)`로 만들어진 둘은 전혀 다른 객체이고 Realm을 통해 Delete를 하려고 하면 후자의 경우 Realm Object가 아니기 때문에 취급이 불가능하다는 것입니다.
+```swift
+undoManager.registerUndo(withTarget: self) { [weak self] _ in
+    self?.registerAddRedoAction(task: task)    // Error!
+    do {
+        try self?.realmManager.delete(task: task) // Error!
+    } catch {
+        self?.error.accept(DatabaseError.deleteError)
+    }
+}
+```
+#### 해결한 방법
+- `Realm`의 `write transaction`에 쓰인 객체인 경우, 저장된 Realm DB의 주소값을 참조하는 것 같습니다. 따라서 삭제 후 `Undo`를 통해 다시 생성했다고 해도 그 둘은 동일한 객체가 아니기 때문에 반복되는 `Undo`/`Redo` 동작이나 혹은 복합적인 여러 동작을 하는 경우 꼬이는 문제가 발생한 것 같습니다. 
+
+```swift
+// In ViewModel.swift
+private func registerAddUndoAction(task: Task) {
+    // 원본과 동일한 값을 가진 객체 생성
+    let capturedTask = Task(
+        title: task.title,
+        body: task.body,
+        date: task.date,
+        taskType: .todo,
+        id: task.id
+    )
+    // 이 객체를 가지고 Undo/Redo 등록
+    undoManager.registerUndo(withTarget: self) { [weak self] _ in
+        self?.registerAddRedoAction(task: capturedTask)
+        do {
+            try self?.realmManager.delete(task: capturedTask)
+            } catch { ... }
+        }
+    }
+```
+
+- 그리고 삭제하는 방법을 **전달 받은 객체 삭제**에서 **전달 받은 객체의 ID와 동일한 객체를 Realm에서 삭제**로 변경했습니다. 코드가 길어졌지만 안정성은 더 올라갔다고 생각합니다. 
+
+```swift
+func delete(task: Task) throws {
+    do {
+        try realmInstance?.write {
+            let result = realmInstance?.objects(Task.self).where {
+                $0.id == task.id
+            }
+            guard let tasks = result else { return }
+            if let queriedTask = tasks.filter({ $0 == $0 }).first {
+                realmInstance?.delete(queriedTask)
+            }
+        }
+    } catch { ... }
+}
+```
+
+<br>
+
+## 🤔 STEP 4 해결하지 못한 부분
+### 1. UndoManager의 canUndo, canRedo 프로퍼티를 직접적으로 버튼에 bind 할 수 없을까?
+- 현재는 `MainViewModel`의 `undoable`, `redoable`값을 통해 `MainViewController`에서는 버튼의 `isEnabled`상태값을 변경하고 있습니다. 
+- 그런데 `UndoManager`의 `canUndo`, `canRedo` 프로퍼티를 사용한다면 굳이 `undoable`, `redoable`가 필요없지 않을까 생각이 들었습니다. 만약 적용 가능하다면 버튼을 눌렀을 때 하는 동작에서도 상황에 따른 상태 변화를 직접 계산해서 입력해주어야 하는 번거로움을 해결할 수 있을 것 같습니다.
 
 <br>
 


### PR DESCRIPTION
안녕하세요 라자냐! @wonhee009
Donnie, Grumpy 입니다.
[STEP 2] 마지막 PR 보내드립니다!
잘 부탁 드립니다!! 🙇🏻🙇🏻‍♂️

<br>

## ⏳ 프로젝트 진행과정
- **[STEP 4-1]**
    - Undo, Redo 기능 구현
- **[STEP 4-2]**
    - UserNotification 기능 구현
- **[STEP 4-3]**
    - 소스 코드 리팩토링
    - 버그 수정

<br>

## 🔧 구현 내용 및 실행 화면    
### 마감일 오전 9시에 로컬 노티피케이션으로 마감일을 알립니다
|화면 녹화 기준(28일)인 일정만 알림이 옵니다.|
|:---:|
|<img width="100%" alt="스크린샷 2022-07-22 오후 8 29 43" src="https://user-images.githubusercontent.com/74251593/181467038-0ada2c74-c857-4db5-bcac-3a924be85d7e.gif">|

### 마감일이 변경되면 알림의 날짜를 변경합니다
|마감일이 지난 일정은 알림이 오지 않습니다.|마감일이 변경되면 알림의 날짜가 변경됩니다.|
|:---:|:---:|
|<img width="100%" alt="스크린샷 2022-07-22 오후 8 29 43" src="https://user-images.githubusercontent.com/74251593/181468162-7341d7a9-03d3-487f-967d-4151f130b1b6.gif">|<img src="https://user-images.githubusercontent.com/74251593/181469495-fea35ccf-bdc9-4de4-890d-993a8b380aae.gif" width="100%">|

### 할일을 완료하면 설정해 두었던 알림을 해제합니다
|DONE으로 옮겨진 할일은 알림을 띄우지 않습니다.|
|:---:|
|<img width="100%" alt="스크린샷 2022-07-22 오후 8 29 43" src="https://user-images.githubusercontent.com/63997044/181471662-80adebbc-5fcd-48c6-97cd-44e5e0e5e130.gif">|

## 화면 하단의 버튼을 통해 되돌리기 기능을 수행할 수 있습니다
|생성 -> 이동 -> 이동 -> 히스토리 확인 -> Undo -> Undo -> Undo -> 히스토리 확인|
|:---:|
|<img width="100%" alt="스크린샷 2022-07-22 오후 8 29 43" src="https://user-images.githubusercontent.com/74251593/181463178-cac5921a-f479-437e-bf89-13e06ac660f4.gif">|

### 수행할 내용이 없으면 버튼을 비활성화 합니다
|`Undo`, `Redo` 버튼 활성화/비활성화|
|:---:|
|<img width="100%" alt="스크린샷 2022-07-22 오후 8 29 43" src="https://user-images.githubusercontent.com/74251593/181464180-0872a4ce-eb55-4313-afb6-71943dd9ac55.gif">|

<br>

## 🤔고민한점 및 🤩해결한 부분
### 1. Undo/Redo Action을 등록하는 방법
#### 주요논리구조
1. 생성, 이동, 삭제 등 이벤트가 발생, `Undo`이벤트를 등록 및 저장하는 메서드 호출
2. `registerUndo`에, `Undo`시의 이벤트 저장과 `Redo`이벤트를 등록하는 메서드 호출, `Undo`버튼 활성화
3. `Undo`버튼 클릭시 `registerUndo`에 등록 및 저장된 `Undo`이벤트 실행(생성, 이동, 삭제 전으로 변경)
4. `Redo`버튼 클릭시 `registerUndo`에 등록 및 저장된 `Redo`이벤트 실행(생성, 이동, 삭제 후로 변경)

위와 같은 논리를 바탕으로 `Undo`/`Redo` 기능을 구현해 보았습니다.

<br>

### 2. UserNotification 생성
#### 현재 구현한 `UserNotification` 생성 방식은 다음과 같습니다.
- `fetchTodo()`, `fetchDoing()`, `fetchDone()` 호출 시 등록되어 있는 알림을 모두 제거합니다. 
- 알림을 제거한 후 `identifier`를 `task.id`로 오늘 날짜에 해당하는 알림을 생성합니다.
- 수정, 삭제, 이동이 발생하는 경우 `fetchData()`를 통해 알림을 제거하고 다시 생성합니다.
#### 할일을 완료하면 설정해 두었던 알림을 해제합니다
- 할일을 완료하면 `DONE`으로 항목이 이동하는 상황이라고 생각하였습니다. 
- `DONE`에 해당하는 데이터(`MainViewModel.dones`)는 알림을 제거만 하고 생성하지 않습니다.
#### 오늘 날짜에 해당하는 알림을 생성하는 이유
- 요구사항에 `마감일이 변경되면 알림의 날짜를 변경합니다`라는 문장이 있었으나 마감일이 오늘이 아닌 항목에 대해서는 당장 알림을 생성할 필요가 없다고 판단해서 오늘이 마감일인 항목들만 알림을 생성하도록 구현하였습니다.

<br>

### 3. Undo/Redo 실행 시 Realm Object Access
🙏 공식 문서에 나와있는 내용을 통해 이해한 내용이 아니라 Trouble Shooting으로 인해 이해한 내용이므로 틀릴 수도 있습니다. 혹시 틀린 내용이 있다면 정정 부탁드립니다!
- `Undo`/`Redo` 동작을 사용하다보면 필연적으로 `Realm Object`에 접근해야 합니다. `Undo`/`Redo` 동작 중에 항목을 삭제하는 `action`이 있을 경우 다음 에러들을 볼 수 있었습니다.
    - `"Object has been deleted or invalidated"`  
    - `"Can only delete an object from the Realm it belongs to."`
- `Realm`의 `delete`를 통해 `object`를 삭제하면 `invalidated`상태가 됩니다. `undoManager.registerUndo()`에서 클로저를 캡처하고 사용할 때 `task`에 대한 값들이 필요한데 이때 이미 삭제된 `task`에 접근이 발생하기 때문인 것으로 보입니다.
- 또한 Realm에서 `Create`를 제외한`Delete` 등 쓰기 작업에서는 이미 저장되어 있는 Realm Object만 사용 가능하다는 내용으로 파악했습니다. 
- 즉 fetch를 통해 가져온 `task`와 `let copiedTask = Task(title: task.title ..)`로 만들어진 둘은 전혀 다른 객체이고 Realm을 통해 Delete를 하려고 하면 후자의 경우 Realm Object가 아니기 때문에 취급이 불가능하다는 것입니다.
```swift
undoManager.registerUndo(withTarget: self) { [weak self] _ in
    self?.registerAddRedoAction(task: task)    // Error!
    do {
        try self?.realmManager.delete(task: task) // Error!
    } catch {
        self?.error.accept(DatabaseError.deleteError)
    }
}
```
#### 해결한 방법
- `Realm`의 `write transaction`에 쓰인 객체인 경우, 저장된 Realm DB의 주소값을 참조하는 것 같습니다. 따라서 삭제 후 `Undo`를 통해 다시 생성했다고 해도 그 둘은 동일한 객체가 아니기 때문에 반복되는 `Undo`/`Redo` 동작이나 혹은 복합적인 여러 동작을 하는 경우 꼬이는 문제가 발생한 것 같습니다. 

```swift
// In ViewModel.swift
private func registerAddUndoAction(task: Task) {
    // 원본과 동일한 값을 가진 객체 생성
    let capturedTask = Task(
        title: task.title,
        body: task.body,
        date: task.date,
        taskType: .todo,
        id: task.id
    )
    // 이 객체를 가지고 Undo/Redo 등록
    undoManager.registerUndo(withTarget: self) { [weak self] _ in
        self?.registerAddRedoAction(task: capturedTask)
        do {
            try self?.realmManager.delete(task: capturedTask)
            } catch { ... }
        }
    }
```

- 그리고 삭제하는 방법을 `전달 받은 객체 삭제`에서 `전달 받은 객체의 ID와 동일한 객체를 Realm에서 삭제`로 변경했습니다. 코드가 길어졌지만 안정성은 더 올라갔다고 생각합니다. 

```swift
// In RealmManager.swift
func delete(task: Task) throws {
    do {
        try realmInstance?.write {
            let result = realmInstance?.objects(Task.self).where {
                $0.id == task.id
            }
            guard let tasks = result else { return }
            if let queriedTask = tasks.filter({ $0 == $0 }).first {
                realmInstance?.delete(queriedTask)
            }
        }
    } catch { ... }
}
```

<br>

## 🤔 조언을 얻고 싶은 부분
### 1. 알림 수정 방법
#### 알림을 제거하고 다시 생성하는 이유
- 추가, 수정, 삭제, 이동 모두 작업을 각각 다른 `View Model`에서 하고 있는데, 작업이 끝난 후 `MainViewModel.fetchData()`을 공통적으로 호출합니다.
- `Undo`, `Redo` Action 실행시에도 `todos`, `doings`, `dones`배열과 Local DB의 데이터를 맞춰주기 위해 `MainViewModel.fetchData()`를 호출합니다. 
- 따라서 Task에 변경이 일어나는 경우 위 메서드에서 전체 알림을 삭제한 뒤 새로 생성하였습니다.
- 이 부분은 이전 스텝에서 셀 삭제 시 전체 데이터를 새로고침하는 경우와 비슷한 것 같은데요, 수정이 일어난 항목에 대해서만 알림을 수정하도록 변경하는 것이 좋을까요?

<br>

### 2. UndoManager의 canUndo, canRedo 프로퍼티를 통한 Button State 업데이트
- 현재는 `MainViewModel`의 `undoable`, `redoable`값을 통해 `MainViewController`에서는 버튼의 `isEnabled`상태값을 변경하고 있습니다. 
- 그런데 `UndoManager`의 `canUndo`, `canRedo` 프로퍼티를 사용한다면 굳이 `undoable`, `redoable`가 필요없지 않을까 생각이 들었습니다. 버튼을 눌렀을 때 하는 동작에서도 상황에 따른 상태 변화를 직접 계산해서 입력해주어야 하는 번거로움도 있구요. 
- 그러나 아무리 찾아보아도 뾰족한 힌트를 얻을 수가 없었습니다. 이 부분을 어떻게 개선할 수 있을까요? 

<br>

---