### PR TITLE
프로젝트 관리 앱 [STEP3-2] 두기

### DIFF
--- a/ProjectManager/Podfile
+++ b/ProjectManager/Podfile
@@ -9,7 +9,9 @@ pod 'RxSwift'
 pod 'RxCocoa'
 pod 'SnapKit'
 pod 'RxGesture'
-pod ‘RealmSwift’
+pod 'RealmSwift'
+
+pod 'FirebaseDatabase'
   # Pods for ProjectManager
 
 end

--- a/ProjectManager/Podfile.lock
+++ b/ProjectManager/Podfile.lock
@@ -1,4 +1,35 @@
 PODS:
+  - FirebaseCore (9.2.0):
+    - FirebaseCoreDiagnostics (~> 9.0)
+    - FirebaseCoreInternal (~> 9.0)
+    - GoogleUtilities/Environment (~> 7.7)
+    - GoogleUtilities/Logger (~> 7.7)
+  - FirebaseCoreDiagnostics (9.2.0):
+    - GoogleDataTransport (< 10.0.0, >= 9.1.4)
+    - GoogleUtilities/Environment (~> 7.7)
+    - GoogleUtilities/Logger (~> 7.7)
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+  - FirebaseCoreInternal (9.3.0):
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
+  - FirebaseDatabase (9.2.0):
+    - FirebaseCore (~> 9.0)
+    - leveldb-library (~> 1.22)
+  - GoogleDataTransport (9.1.4):
+    - GoogleUtilities/Environment (~> 7.7)
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+    - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleUtilities/Environment (7.7.0):
+    - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleUtilities/Logger (7.7.0):
+    - GoogleUtilities/Environment
+  - "GoogleUtilities/NSData+zlib (7.7.0)"
+  - leveldb-library (1.22.1)
+  - nanopb (2.30909.0):
+    - nanopb/decode (= 2.30909.0)
+    - nanopb/encode (= 2.30909.0)
+  - nanopb/decode (2.30909.0)
+  - nanopb/encode (2.30909.0)
+  - PromisesObjC (2.1.1)
   - Realm (10.28.2):
     - Realm/Headers (= 10.28.2)
   - Realm/Headers (10.28.2)
@@ -17,6 +48,7 @@ PODS:
   - SwiftLint (0.47.0)
 
 DEPENDENCIES:
+  - FirebaseDatabase
   - RealmSwift
   - RxCocoa
   - RxGesture
@@ -26,6 +58,15 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
+    - FirebaseCore
+    - FirebaseCoreDiagnostics
+    - FirebaseCoreInternal
+    - FirebaseDatabase
+    - GoogleDataTransport
+    - GoogleUtilities
+    - leveldb-library
+    - nanopb
+    - PromisesObjC
     - Realm
     - RealmSwift
     - RxCocoa
@@ -36,6 +77,15 @@ SPEC REPOS:
     - SwiftLint
 
 SPEC CHECKSUMS:
+  FirebaseCore: 0e27f2a15d8f7b7ef11e7d93e23b1cbab55d748c
+  FirebaseCoreDiagnostics: ad3f6c68b7c5b63b7cf15b0785d7137f05f32268
+  FirebaseCoreInternal: 635d1c9a612a6502b6377a0c92af83758076ffff
+  FirebaseDatabase: 0a888e4bcaa8edc43701597daab336201fb47cc9
+  GoogleDataTransport: 5fffe35792f8b96ec8d6775f5eccd83c998d5a3b
+  GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
+  leveldb-library: 50c7b45cbd7bf543c81a468fe557a16ae3db8729
+  nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
+  PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
   Realm: e617c54ad0f566b3d0f6a2abae7010de05f252ac
   RealmSwift: 8a516a8759d80d52ebcec1ff1076f5f5159f98b2
   RxCocoa: 94f817b71c07517321eb4f9ad299112ca8af743b
@@ -45,6 +95,6 @@ SPEC CHECKSUMS:
   SnapKit: e01d52ebb8ddbc333eefe2132acf85c8227d9c25
   SwiftLint: d41cc46a2ae58ac6d9f26954bc89f1d72e71fdef
 
-PODFILE CHECKSUM: c9c72d2498324efbba727f992b734ab3de511c27
+PODFILE CHECKSUM: 931d5de0aecaa048aa798506757c4ebdfb551655
 
 COCOAPODS: 1.11.3

--- a/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
+++ b/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		ACA39AD5287DEC1700AE4964 /* AddViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA39AD4287DEC1700AE4964 /* AddViewModel.swift */; };
 		ACC1F0E928827C7900216C15 /* EditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC1F0E828827C7900216C15 /* EditViewModel.swift */; };
 		ACCBF0F02877CACA00FEC0F3 /* DateConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACCBF0EF2877CACA00FEC0F3 /* DateConverter.swift */; };
+		ACCDAB92288E96AD009B1DD7 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = ACCDAB91288E96AD009B1DD7 /* GoogleService-Info.plist */; };
 		ACD9CB2D28749F6400B0A6CF /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD9CB2C28749F6400B0A6CF /* HeaderView.swift */; };
 		ACDD285C2886FEFC0083356A /* AppStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDD285B2886FEFC0083356A /* AppStorage.swift */; };
 		ACDD285E2887178F0083356A /* LocalStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDD285D2887178F0083356A /* LocalStorageManager.swift */; };
@@ -51,6 +52,7 @@
 		ACA39AD4287DEC1700AE4964 /* AddViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddViewModel.swift; sourceTree = "<group>"; };
 		ACC1F0E828827C7900216C15 /* EditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditViewModel.swift; sourceTree = "<group>"; };
 		ACCBF0EF2877CACA00FEC0F3 /* DateConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateConverter.swift; sourceTree = "<group>"; };
+		ACCDAB91288E96AD009B1DD7 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		ACD9CB2C28749F6400B0A6CF /* HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
 		ACDD285B2886FEFC0083356A /* AppStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStorage.swift; sourceTree = "<group>"; };
 		ACDD285D2887178F0083356A /* LocalStorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalStorageManager.swift; sourceTree = "<group>"; };
@@ -186,6 +188,7 @@
 				C7431F0E25F51E1E0094C4CF /* Assets.xcassets */,
 				C7431F1025F51E1E0094C4CF /* LaunchScreen.storyboard */,
 				C7431F1325F51E1E0094C4CF /* Info.plist */,
+				ACCDAB91288E96AD009B1DD7 /* GoogleService-Info.plist */,
 			);
 			path = ProjectManager;
 			sourceTree = "<group>";
@@ -259,6 +262,7 @@
 			files = (
 				C7431F1225F51E1E0094C4CF /* LaunchScreen.storyboard in Resources */,
 				C7431F0F25F51E1E0094C4CF /* Assets.xcassets in Resources */,
+				ACCDAB92288E96AD009B1DD7 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
+++ b/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		14391D15E9073FB568E4F24D /* Pods_ProjectManager.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9BC5940E20276FB64A885633 /* Pods_ProjectManager.framework */; };
+		AC035E932890D7BF0068DC7E /* History.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC035E922890D7BF0068DC7E /* History.swift */; };
 		AC15AB932876E2BC004B5E8A /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC15AB922876E2BC004B5E8A /* DetailView.swift */; };
 		AC54B7A02875478700092D83 /* ListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC54B79F2875478700092D83 /* ListItem.swift */; };
 		AC54B7A2287549F800092D83 /* ListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC54B7A1287549F800092D83 /* ListTableViewCell.swift */; };
@@ -39,6 +40,7 @@
 		275580651BF567068A8E517A /* Pods-ProjectManager.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProjectManager.debug.xcconfig"; path = "Target Support Files/Pods-ProjectManager/Pods-ProjectManager.debug.xcconfig"; sourceTree = "<group>"; };
 		9B82BA3364C1F3335ED7823D /* Pods-ProjectManager.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProjectManager.release.xcconfig"; path = "Target Support Files/Pods-ProjectManager/Pods-ProjectManager.release.xcconfig"; sourceTree = "<group>"; };
 		9BC5940E20276FB64A885633 /* Pods_ProjectManager.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ProjectManager.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AC035E922890D7BF0068DC7E /* History.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = History.swift; sourceTree = "<group>"; };
 		AC15AB922876E2BC004B5E8A /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		AC54B79F2875478700092D83 /* ListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItem.swift; sourceTree = "<group>"; };
 		AC54B7A1287549F800092D83 /* ListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTableViewCell.swift; sourceTree = "<group>"; };
@@ -107,6 +109,7 @@
 				AC54B79F2875478700092D83 /* ListItem.swift */,
 				ACDD285F288717D60083356A /* ListItemDTO.swift */,
 				AC60141B288A540D005CA2F4 /* LocalStorage.swift */,
+				AC035E922890D7BF0068DC7E /* History.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -331,6 +334,7 @@
 				ACA39AD1287DE50200AE4964 /* EditViewController.swift in Sources */,
 				ACDD285E2887178F0083356A /* LocalStorageManager.swift in Sources */,
 				ACDD2860288717D60083356A /* ListItemDTO.swift in Sources */,
+				AC035E932890D7BF0068DC7E /* History.swift in Sources */,
 				ACA39ACD287DE05200AE4964 /* Container.swift in Sources */,
 				AC9C57C3287A8CC100BA7F7D /* UITableView + Extension.swift in Sources */,
 				AC54B7A02875478700092D83 /* ListItem.swift in Sources */,

--- a/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
+++ b/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		ACC1F0E928827C7900216C15 /* EditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC1F0E828827C7900216C15 /* EditViewModel.swift */; };
 		ACCBF0F02877CACA00FEC0F3 /* DateConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACCBF0EF2877CACA00FEC0F3 /* DateConverter.swift */; };
 		ACCDAB92288E96AD009B1DD7 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = ACCDAB91288E96AD009B1DD7 /* GoogleService-Info.plist */; };
+		ACCDAB94288E96E9009B1DD7 /* NetworkStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACCDAB93288E96E9009B1DD7 /* NetworkStorage.swift */; };
 		ACD9CB2D28749F6400B0A6CF /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD9CB2C28749F6400B0A6CF /* HeaderView.swift */; };
 		ACDD285C2886FEFC0083356A /* AppStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDD285B2886FEFC0083356A /* AppStorage.swift */; };
 		ACDD285E2887178F0083356A /* LocalStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDD285D2887178F0083356A /* LocalStorageManager.swift */; };
@@ -53,6 +54,7 @@
 		ACC1F0E828827C7900216C15 /* EditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditViewModel.swift; sourceTree = "<group>"; };
 		ACCBF0EF2877CACA00FEC0F3 /* DateConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateConverter.swift; sourceTree = "<group>"; };
 		ACCDAB91288E96AD009B1DD7 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		ACCDAB93288E96E9009B1DD7 /* NetworkStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStorage.swift; sourceTree = "<group>"; };
 		ACD9CB2C28749F6400B0A6CF /* HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
 		ACDD285B2886FEFC0083356A /* AppStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStorage.swift; sourceTree = "<group>"; };
 		ACDD285D2887178F0083356A /* LocalStorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalStorageManager.swift; sourceTree = "<group>"; };
@@ -143,6 +145,7 @@
 			children = (
 				ACDD285B2886FEFC0083356A /* AppStorage.swift */,
 				ACDD285D2887178F0083356A /* LocalStorageManager.swift */,
+				ACCDAB93288E96E9009B1DD7 /* NetworkStorage.swift */,
 				AC601417288A3C13005CA2F4 /* StorageError.swift */,
 			);
 			path = Storage;
@@ -317,6 +320,7 @@
 			files = (
 				ACC1F0E928827C7900216C15 /* EditViewModel.swift in Sources */,
 				AC54B7A5287557BF00092D83 /* MainViewModel.swift in Sources */,
+				ACCDAB94288E96E9009B1DD7 /* NetworkStorage.swift in Sources */,
 				AC15AB932876E2BC004B5E8A /* DetailView.swift in Sources */,
 				C7431F0A25F51E1D0094C4CF /* MainViewController.swift in Sources */,
 				ACCBF0F02877CACA00FEC0F3 /* DateConverter.swift in Sources */,

--- a/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
+++ b/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		14391D15E9073FB568E4F24D /* Pods_ProjectManager.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9BC5940E20276FB64A885633 /* Pods_ProjectManager.framework */; };
 		AC035E932890D7BF0068DC7E /* History.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC035E922890D7BF0068DC7E /* History.swift */; };
+		AC035E962890EF350068DC7E /* HistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC035E952890EF350068DC7E /* HistoryViewController.swift */; };
+		AC035E982890EF570068DC7E /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC035E972890EF570068DC7E /* HistoryView.swift */; };
+		AC035E9A2890EF6C0068DC7E /* HistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC035E992890EF6C0068DC7E /* HistoryViewModel.swift */; };
 		AC15AB932876E2BC004B5E8A /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC15AB922876E2BC004B5E8A /* DetailView.swift */; };
 		AC54B7A02875478700092D83 /* ListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC54B79F2875478700092D83 /* ListItem.swift */; };
 		AC54B7A2287549F800092D83 /* ListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC54B7A1287549F800092D83 /* ListTableViewCell.swift */; };
@@ -41,6 +44,9 @@
 		9B82BA3364C1F3335ED7823D /* Pods-ProjectManager.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProjectManager.release.xcconfig"; path = "Target Support Files/Pods-ProjectManager/Pods-ProjectManager.release.xcconfig"; sourceTree = "<group>"; };
 		9BC5940E20276FB64A885633 /* Pods_ProjectManager.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ProjectManager.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC035E922890D7BF0068DC7E /* History.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = History.swift; sourceTree = "<group>"; };
+		AC035E952890EF350068DC7E /* HistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewController.swift; sourceTree = "<group>"; };
+		AC035E972890EF570068DC7E /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryView.swift; sourceTree = "<group>"; };
+		AC035E992890EF6C0068DC7E /* HistoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewModel.swift; sourceTree = "<group>"; };
 		AC15AB922876E2BC004B5E8A /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		AC54B79F2875478700092D83 /* ListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItem.swift; sourceTree = "<group>"; };
 		AC54B7A1287549F800092D83 /* ListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTableViewCell.swift; sourceTree = "<group>"; };
@@ -82,6 +88,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		AC035E942890EF160068DC7E /* History */ = {
+			isa = PBXGroup;
+			children = (
+				AC035E952890EF350068DC7E /* HistoryViewController.swift */,
+				AC035E992890EF6C0068DC7E /* HistoryViewModel.swift */,
+				AC035E972890EF570068DC7E /* HistoryView.swift */,
+			);
+			path = History;
+			sourceTree = "<group>";
+		};
 		AC15AB942876E80E004B5E8A /* Detail */ = {
 			isa = PBXGroup;
 			children = (
@@ -99,6 +115,7 @@
 			children = (
 				ACA39AD6287DF77800AE4964 /* Main */,
 				AC15AB942876E80E004B5E8A /* Detail */,
+				AC035E942890EF160068DC7E /* History */,
 			);
 			path = Scene;
 			sourceTree = "<group>";
@@ -328,14 +345,17 @@
 				C7431F0A25F51E1D0094C4CF /* MainViewController.swift in Sources */,
 				ACCBF0F02877CACA00FEC0F3 /* DateConverter.swift in Sources */,
 				AC601418288A3C13005CA2F4 /* StorageError.swift in Sources */,
+				AC035E982890EF570068DC7E /* HistoryView.swift in Sources */,
 				C7431F0625F51E1D0094C4CF /* AppDelegate.swift in Sources */,
 				AC60141C288A540D005CA2F4 /* LocalStorage.swift in Sources */,
 				C7431F0825F51E1D0094C4CF /* SceneDelegate.swift in Sources */,
+				AC035E9A2890EF6C0068DC7E /* HistoryViewModel.swift in Sources */,
 				ACA39AD1287DE50200AE4964 /* EditViewController.swift in Sources */,
 				ACDD285E2887178F0083356A /* LocalStorageManager.swift in Sources */,
 				ACDD2860288717D60083356A /* ListItemDTO.swift in Sources */,
 				AC035E932890D7BF0068DC7E /* History.swift in Sources */,
 				ACA39ACD287DE05200AE4964 /* Container.swift in Sources */,
+				AC035E962890EF350068DC7E /* HistoryViewController.swift in Sources */,
 				AC9C57C3287A8CC100BA7F7D /* UITableView + Extension.swift in Sources */,
 				AC54B7A02875478700092D83 /* ListItem.swift in Sources */,
 				AC60141A288A487F005CA2F4 /* UIViewController + Extension.swift in Sources */,

--- a/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
+++ b/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		ACDD285C2886FEFC0083356A /* AppStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDD285B2886FEFC0083356A /* AppStorage.swift */; };
 		ACDD285E2887178F0083356A /* LocalStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDD285D2887178F0083356A /* LocalStorageManager.swift */; };
 		ACDD2860288717D60083356A /* ListItemDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDD285F288717D60083356A /* ListItemDTO.swift */; };
+		ACE2F88428923CCB0016526E /* HistoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACE2F88328923CCB0016526E /* HistoryTableViewCell.swift */; };
 		C7431F0625F51E1D0094C4CF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7431F0525F51E1D0094C4CF /* AppDelegate.swift */; };
 		C7431F0825F51E1D0094C4CF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7431F0725F51E1D0094C4CF /* SceneDelegate.swift */; };
 		C7431F0A25F51E1D0094C4CF /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7431F0925F51E1D0094C4CF /* MainViewController.swift */; };
@@ -67,6 +68,7 @@
 		ACDD285B2886FEFC0083356A /* AppStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStorage.swift; sourceTree = "<group>"; };
 		ACDD285D2887178F0083356A /* LocalStorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalStorageManager.swift; sourceTree = "<group>"; };
 		ACDD285F288717D60083356A /* ListItemDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItemDTO.swift; sourceTree = "<group>"; };
+		ACE2F88328923CCB0016526E /* HistoryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryTableViewCell.swift; sourceTree = "<group>"; };
 		C7431F0225F51E1D0094C4CF /* ProjectManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ProjectManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7431F0525F51E1D0094C4CF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C7431F0725F51E1D0094C4CF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -94,6 +96,7 @@
 				AC035E952890EF350068DC7E /* HistoryViewController.swift */,
 				AC035E992890EF6C0068DC7E /* HistoryViewModel.swift */,
 				AC035E972890EF570068DC7E /* HistoryView.swift */,
+				ACE2F88328923CCB0016526E /* HistoryTableViewCell.swift */,
 			);
 			path = History;
 			sourceTree = "<group>";
@@ -356,6 +359,7 @@
 				AC035E932890D7BF0068DC7E /* History.swift in Sources */,
 				ACA39ACD287DE05200AE4964 /* Container.swift in Sources */,
 				AC035E962890EF350068DC7E /* HistoryViewController.swift in Sources */,
+				ACE2F88428923CCB0016526E /* HistoryTableViewCell.swift in Sources */,
 				AC9C57C3287A8CC100BA7F7D /* UITableView + Extension.swift in Sources */,
 				AC54B7A02875478700092D83 /* ListItem.swift in Sources */,
 				AC60141A288A487F005CA2F4 /* UIViewController + Extension.swift in Sources */,

--- a/ProjectManager/ProjectManager/AppDelegate.swift
+++ b/ProjectManager/ProjectManager/AppDelegate.swift
@@ -5,6 +5,7 @@
 // 
 
 import UIKit
+import FirebaseCore
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -12,7 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        FirebaseApp.configure()
         return true
     }
 

--- a/ProjectManager/ProjectManager/Container.swift
+++ b/ProjectManager/ProjectManager/Container.swift
@@ -38,16 +38,20 @@ final class Container {
         return EditViewModel(storage: storage, item: listItem)
     }
     
-    func makeHistoryViewController(sourceView: UIView, bounds: CGRect) -> HistoryViewController {
-        let historyVC = HistoryViewController()
+    func makeHistoryViewController(sourceView: UIView, bounds: CGRect, history: [History]) -> HistoryViewController {
+        let historyVC = HistoryViewController(viewModel: makeHistoryViewModel(history))
         historyVC.modalPresentationStyle = .popover
         guard let popover = historyVC.popoverPresentationController else {
-            return HistoryViewController()
+            return historyVC
         }
         popover.sourceView = sourceView
         popover.sourceRect = CGRect(x: bounds.minX, y: bounds.minY + 20, width: bounds.width, height: bounds.height)
         
         return historyVC
+    }
+    
+    private func makeHistoryViewModel(_ history: [History]) -> HistoryViewModelable {
+        return HistoryViewModel(history: history)
     }
     
     init(storage: AppStoregeable) {

--- a/ProjectManager/ProjectManager/Container.swift
+++ b/ProjectManager/ProjectManager/Container.swift
@@ -5,6 +5,7 @@
 //  Created by 두기 on 2022/07/13.
 //
 import Network
+import UIKit
 
 final class Container {
     private let storage: AppStoregeable
@@ -35,6 +36,18 @@ final class Container {
 
     private func makeEditViewModel(_ listItem: ListItem) -> EditViewModelable {
         return EditViewModel(storage: storage, item: listItem)
+    }
+    
+    func makeHistoryViewController(sourceView: UIView, bounds: CGRect) -> HistoryViewController {
+        let historyVC = HistoryViewController()
+        historyVC.modalPresentationStyle = .popover
+        guard let popover = historyVC.popoverPresentationController else {
+            return HistoryViewController()
+        }
+        popover.sourceView = sourceView
+        popover.sourceRect = CGRect(x: bounds.minX, y: bounds.minY + 20, width: bounds.width, height: bounds.height)
+        
+        return historyVC
     }
     
     init(storage: AppStoregeable) {

--- a/ProjectManager/ProjectManager/Container.swift
+++ b/ProjectManager/ProjectManager/Container.swift
@@ -4,6 +4,7 @@
 //
 //  Created by 두기 on 2022/07/13.
 //
+import Network
 
 final class Container {
     private let storage: AppStoregeable
@@ -13,7 +14,7 @@ final class Container {
     }
     
     private func makeMainViewModel() -> MainViewModelInOut {
-        return MainViewModel(storage: storage)
+        return MainViewModel(storage: storage, networkMonitor: NWPathMonitor())
     }
     
     func makeAddViewController() -> AddViewController {

--- a/ProjectManager/ProjectManager/Container.swift
+++ b/ProjectManager/ProjectManager/Container.swift
@@ -41,6 +41,7 @@ final class Container {
     func makeHistoryViewController(sourceView: UIView, bounds: CGRect, history: [History]) -> HistoryViewController {
         let historyVC = HistoryViewController(viewModel: makeHistoryViewModel(history))
         historyVC.modalPresentationStyle = .popover
+        historyVC.preferredContentSize = CGSize(width: 500, height: 500)
         guard let popover = historyVC.popoverPresentationController else {
             return historyVC
         }

--- a/ProjectManager/ProjectManager/GoogleService-Info.plist
+++ b/ProjectManager/ProjectManager/GoogleService-Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>510340208979-5hnm0lktdoab0a8kme3glna5jt8ql60c.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.510340208979-5hnm0lktdoab0a8kme3glna5jt8ql60c</string>
+	<key>API_KEY</key>
+	<string>AIzaSyBvKc_GOnungvf-3k2YhWPCFeX3l9lRNQU</string>
+	<key>GCM_SENDER_ID</key>
+	<string>510340208979</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>net.yagom.ProjectManager</string>
+	<key>PROJECT_ID</key>
+	<string>project-manager-5f1e5</string>
+	<key>STORAGE_BUCKET</key>
+	<string>project-manager-5f1e5.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:510340208979:ios:ebe186347606c07f73a9a6</string>
+</dict>
+</plist>

--- a/ProjectManager/ProjectManager/Model/History.swift
+++ b/ProjectManager/ProjectManager/Model/History.swift
@@ -1,0 +1,13 @@
+//
+//  History.swift
+//  ProjectManager
+//
+//  Created by 두기 on 2022/07/27.
+//
+
+import RealmSwift
+
+final class History: Object {
+    @Persisted var title: String
+    @Persisted var editedDate: Date = Date()
+}

--- a/ProjectManager/ProjectManager/Model/ListItem.swift
+++ b/ProjectManager/ProjectManager/Model/ListItem.swift
@@ -13,17 +13,6 @@ struct ListItem {
     var deadline: Date
     var type: ListType = .todo
     let id: String
-    
-    var convertedItem: ListItemDTO {
-        let itemModel = ListItemDTO()
-        itemModel.title = self.title
-        itemModel.body = self.body
-        itemModel.deadline = self.deadline
-        itemModel.type = self.type.rawValue
-        itemModel.id = self.id
-        
-        return itemModel
-    }
 }
 
 enum ListType: String {

--- a/ProjectManager/ProjectManager/Model/ListItemDTO.swift
+++ b/ProjectManager/ProjectManager/Model/ListItemDTO.swift
@@ -8,9 +8,9 @@
 import RealmSwift
 
 final class ListItemDTO: Object {
-    @Persisted var title: String = ""
-    @Persisted var body: String = ""
-    @Persisted var deadline: Date = Date()
-    @Persisted var type: String = ""
-    @Persisted(primaryKey: true) var id: String = ""
+    @Persisted var title: String
+    @Persisted var body: String
+    @Persisted var deadline: Date
+    @Persisted var type: String
+    @Persisted(primaryKey: true) var id: String
 }

--- a/ProjectManager/ProjectManager/Model/ListItemDTO.swift
+++ b/ProjectManager/ProjectManager/Model/ListItemDTO.swift
@@ -13,12 +13,4 @@ final class ListItemDTO: Object {
     @Persisted var deadline: Date = Date()
     @Persisted var type: String = ""
     @Persisted(primaryKey: true) var id: String = ""
-    
-    var convertedItem: ListItem {
-        return ListItem(title: self.title,
-                        body: self.body,
-                        deadline: self.deadline,
-                        type: ListType(rawValue: self.type) ?? .todo,
-                        id: self.id)
-    }
 }

--- a/ProjectManager/ProjectManager/Model/LocalStorage.swift
+++ b/ProjectManager/ProjectManager/Model/LocalStorage.swift
@@ -11,4 +11,5 @@ final class LocalStorage: Object {
     let todoList = List<ListItemDTO>()
     let doingList = List<ListItemDTO>()
     let doneList = List<ListItemDTO>()
+    let history = List<History>()
 }

--- a/ProjectManager/ProjectManager/Scene/Detail/AddViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/Detail/AddViewController.swift
@@ -76,7 +76,7 @@ final class AddViewController: UIViewController {
         
         viewModel.showErrorAlert
             .bind(onNext: { [weak self] in
-                self?.showErrorAlert(messege: $0)
+                self?.showErrorAlert(message: $0)
             })
             .disposed(by: disposebag)
     }

--- a/ProjectManager/ProjectManager/Scene/Detail/AddViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Detail/AddViewModel.swift
@@ -12,7 +12,7 @@ protocol AddViewModelable: AddViewModelOutput, AddViewModelInput {}
 protocol AddViewModelOutput {
     var list: ListItem { get }
     var dismiss: PublishRelay<Void> { get }
-    var showErrorAlert: PublishRelay<String> { get }
+    var showErrorAlert: PublishRelay<String?> { get }
 }
 
 protocol AddViewModelInput {
@@ -28,7 +28,7 @@ final class AddViewModel: AddViewModelable {
     
     var list: ListItem
     var dismiss = PublishRelay<Void>()
-    var showErrorAlert = PublishRelay<String>()
+    var showErrorAlert = PublishRelay<String?>()
     
     init(storage: AppStoregeable) {
         self.storage = storage
@@ -57,6 +57,7 @@ final class AddViewModel: AddViewModelable {
             dismiss.accept(())
         } catch {
             guard let error = error as? StorageError else {
+                showErrorAlert.accept(nil)
                 return
             }
             showErrorAlert.accept(error.errorDescription)

--- a/ProjectManager/ProjectManager/Scene/Detail/AddViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Detail/AddViewModel.swift
@@ -53,7 +53,8 @@ final class AddViewModel: AddViewModelable {
     
     func touchDoneButton() {
         do {
-        try storage.creatItem(listItem: list)
+            try storage.creatItem(listItem: list)
+            try storage.makeHistory(title: "Added '\(list.title)'.")
             dismiss.accept(())
         } catch {
             guard let error = error as? StorageError else {

--- a/ProjectManager/ProjectManager/Scene/Detail/EditViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/Detail/EditViewController.swift
@@ -84,7 +84,7 @@ final class EditViewController: UIViewController {
         .disposed(by: disposebag)
         
         viewModel.showErrorAlert.bind(onNext: {[weak self] in
-            self?.showErrorAlert(messege: $0)
+            self?.showErrorAlert(message: $0)
         })
         .disposed(by: disposebag)
     }

--- a/ProjectManager/ProjectManager/Scene/Detail/EditViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Detail/EditViewModel.swift
@@ -13,7 +13,7 @@ protocol EditViewModelOutput {
     var list: ListItem { get }
     var isEditable: BehaviorRelay<Bool> { get }
     var dismiss: PublishRelay<Void> { get }
-    var showErrorAlert: PublishRelay<String> { get }
+    var showErrorAlert: PublishRelay<String?> { get }
 }
 
 protocol EditViewModelInput {
@@ -31,7 +31,7 @@ final class EditViewModel: EditViewModelable {
     var list: ListItem
     var isEditable = BehaviorRelay<Bool>(value: false)
     var dismiss = PublishRelay<Void>()
-    var showErrorAlert = PublishRelay<String>()
+    var showErrorAlert = PublishRelay<String?>()
     
     init(storage: AppStoregeable, item: ListItem) {
         self.storage = storage
@@ -65,6 +65,7 @@ final class EditViewModel: EditViewModelable {
             dismiss.accept(())
         } catch {
             guard let error = error as? StorageError else {
+                showErrorAlert.accept(nil)
                 return
             }
             showErrorAlert.accept(error.errorDescription)

--- a/ProjectManager/ProjectManager/Scene/History/HistoryTableViewCell.swift
+++ b/ProjectManager/ProjectManager/Scene/History/HistoryTableViewCell.swift
@@ -1,0 +1,25 @@
+//
+//  HistoryTableViewCell.swift
+//  ProjectManager
+//
+//  Created by 두기 on 2022/07/28.
+//
+
+import UIKit
+
+class HistoryTableViewCell: UITableViewCell {
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setViewLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+
+    private func setViewLayout() {
+        self.backgroundColor = .systemBlue
+    }
+}

--- a/ProjectManager/ProjectManager/Scene/History/HistoryTableViewCell.swift
+++ b/ProjectManager/ProjectManager/Scene/History/HistoryTableViewCell.swift
@@ -17,9 +17,38 @@ class HistoryTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    private lazy var mainStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, dateLabel])
+        stackView.distribution = .fillEqually
+        stackView.axis = .vertical
+        
+        return stackView
+    }()
     
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        
+        return label
+    }()
+    
+    private lazy var dateLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .subheadline)
+        label.textColor = .systemGray
+        
+        return label
+    }()
 
     private func setViewLayout() {
-        self.backgroundColor = .systemBlue
+        self.addSubview(mainStackView)
+        
+        mainStackView.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(10)
+        }
+    }
+    
+    func setCellContents(_ history: History) {
+        titleLabel.text = history.title
+        dateLabel.text = DateConverter.historyDateString(history.editedDate)
     }
 }

--- a/ProjectManager/ProjectManager/Scene/History/HistoryView.swift
+++ b/ProjectManager/ProjectManager/Scene/History/HistoryView.swift
@@ -19,7 +19,7 @@ final class HistoryView: UIView {
     
     private(set) lazy var historyTableView: UITableView = {
         let tableView = UITableView()
-        tableView.backgroundColor = .red
+        tableView.separatorInset = UIEdgeInsets(top: 0, left: -20, bottom: 0, right: 0)
         tableView.register(HistoryTableViewCell.self)
         return tableView
     }()
@@ -27,7 +27,7 @@ final class HistoryView: UIView {
     private func setLayout() {
         self.addSubview(historyTableView)
         historyTableView.snp.makeConstraints {
-            $0.top.leading.trailing.equalToSuperview().inset(20)
+            $0.edges.equalToSuperview().inset(20)
         }
     }
 }

--- a/ProjectManager/ProjectManager/Scene/History/HistoryView.swift
+++ b/ProjectManager/ProjectManager/Scene/History/HistoryView.swift
@@ -1,0 +1,12 @@
+//
+//  HistoryView.swift
+//  ProjectManager
+//
+//  Created by 두기 on 2022/07/27.
+//
+
+import UIKit
+
+final class HistoryView: UIView {
+    
+}

--- a/ProjectManager/ProjectManager/Scene/History/HistoryView.swift
+++ b/ProjectManager/ProjectManager/Scene/History/HistoryView.swift
@@ -20,6 +20,7 @@ final class HistoryView: UIView {
     private(set) lazy var historyTableView: UITableView = {
         let tableView = UITableView()
         tableView.backgroundColor = .red
+        tableView.register(HistoryTableViewCell.self)
         return tableView
     }()
     

--- a/ProjectManager/ProjectManager/Scene/History/HistoryView.swift
+++ b/ProjectManager/ProjectManager/Scene/History/HistoryView.swift
@@ -5,8 +5,28 @@
 //  Created by 두기 on 2022/07/27.
 //
 
-import UIKit
+import SnapKit
 
 final class HistoryView: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setLayout()
+    }
     
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private(set) lazy var historyTableView: UITableView = {
+        let tableView = UITableView()
+        tableView.backgroundColor = .red
+        return tableView
+    }()
+    
+    private func setLayout() {
+        self.addSubview(historyTableView)
+        historyTableView.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview().inset(20)
+        }
+    }
 }

--- a/ProjectManager/ProjectManager/Scene/History/HistoryViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/History/HistoryViewController.swift
@@ -26,4 +26,8 @@ final class HistoryViewController: UIViewController {
         self.view = historyView
     }
     
+    private func bindView() {
+        historyView.historyTableView.register(HistoryTableViewCell.self)
+
+    }
 }

--- a/ProjectManager/ProjectManager/Scene/History/HistoryViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/History/HistoryViewController.swift
@@ -1,0 +1,12 @@
+//
+//  HistoryViewController.swift
+//  ProjectManager
+//
+//  Created by 두기 on 2022/07/27.
+//
+
+import UIKit
+
+final class HistoryViewController: UIViewController {
+    
+}

--- a/ProjectManager/ProjectManager/Scene/History/HistoryViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/History/HistoryViewController.swift
@@ -9,4 +9,12 @@ import UIKit
 
 final class HistoryViewController: UIViewController {
     
+    
+    let historyView = HistoryView()
+    
+    override func loadView() {
+        super.loadView()
+        self.view = historyView
+    }
+    
 }

--- a/ProjectManager/ProjectManager/Scene/History/HistoryViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/History/HistoryViewController.swift
@@ -5,7 +5,7 @@
 //  Created by 두기 on 2022/07/27.
 //
 
-import UIKit
+import RxSwift
 
 final class HistoryViewController: UIViewController {
     let viewModel: HistoryViewModelable
@@ -20,14 +20,29 @@ final class HistoryViewController: UIViewController {
     }
     
     let historyView = HistoryView()
+    let disposeBag = DisposeBag()
     
     override func loadView() {
         super.loadView()
         self.view = historyView
     }
     
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        bindView()
+    }
+    
     private func bindView() {
-        historyView.historyTableView.register(HistoryTableViewCell.self)
-
+        viewModel.hitory
+            .bind(to: historyView.historyTableView.rx.items(cellIdentifier: "\(HistoryTableViewCell.self)", cellType: HistoryTableViewCell.self)) { index, item, cell in
+                cell.setCellContents(item)
+        }
+        .disposed(by: disposeBag)
+        
+        historyView.historyTableView.rx.itemSelected
+            .bind(onNext: { [weak self] in
+                self?.historyView.historyTableView.deselectRow(at: $0, animated: true)
+            })
+            .disposed(by: disposeBag)
     }
 }

--- a/ProjectManager/ProjectManager/Scene/History/HistoryViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/History/HistoryViewController.swift
@@ -8,7 +8,16 @@
 import UIKit
 
 final class HistoryViewController: UIViewController {
+    let viewModel: HistoryViewModelable
     
+    init(viewModel: HistoryViewModelable) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     let historyView = HistoryView()
     

--- a/ProjectManager/ProjectManager/Scene/History/HistoryViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/History/HistoryViewModel.swift
@@ -1,0 +1,10 @@
+//
+//  HistoryViewModel.swift
+//  ProjectManager
+//
+//  Created by 두기 on 2022/07/27.
+//
+
+final class HistoryViewModel {
+    
+}

--- a/ProjectManager/ProjectManager/Scene/History/HistoryViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/History/HistoryViewModel.swift
@@ -5,6 +5,21 @@
 //  Created by 두기 on 2022/07/27.
 //
 
-final class HistoryViewModel {
+import RxRelay
+
+protocol HistoryViewModelable: HistoryViewModelInput, HistoryViewModelOutput {}
+
+protocol HistoryViewModelInput {}
+
+protocol HistoryViewModelOutput {
+    var hitory: BehaviorRelay<[History]> { get }
+}
+
+final class HistoryViewModel: HistoryViewModelable {
+    init(history: [History]) {
+        self.hitory = BehaviorRelay<[History]>(value: history)
+    }
     
+    //out
+    var hitory: BehaviorRelay<[History]>
 }

--- a/ProjectManager/ProjectManager/Scene/Main/ListTableViewCell.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/ListTableViewCell.swift
@@ -69,7 +69,7 @@ extension ListTableViewCell {
         self.backgroundColor = .systemGray6
         titleLabel.text = listItem.title
         bodyLabel.text = listItem.body
-        deadlineLabel.text = DateConverter.dateToString(listItem.deadline)
+        deadlineLabel.text = DateConverter.listDateString(listItem.deadline)
         deadlineLabel.textColor = isOver ? .red : .label
     }
     

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
@@ -116,7 +116,7 @@ final class MainViewController: UIViewController {
         .disposed(by: disposebag)
         
         viewModel.showNetworkErrorAlert.bind(onNext: { [weak self] in
-            self?.showNetworkErrorAlert()
+            self?.showExitAlert(message: $0.errorDescription)
         })
         .disposed(by: disposebag)
         

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
@@ -74,6 +74,11 @@ final class MainViewController: UIViewController {
             self?.showErrorAlert(messege: $0)
         })
         .disposed(by: disposebag)
+        
+        viewModel.showNetworkErrorAlert.bind(onNext: { [weak self] in
+            self?.showNetworkErrorAlert()
+        })
+        .disposed(by: disposebag)
     }
     
     private func bindTableView() {

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
@@ -39,17 +39,33 @@ final class MainViewController: UIViewController {
     
     private func setInitialView() {
         self.view.backgroundColor = .systemGray5
-        self.navigationItem.rightBarButtonItem = addButton
+        self.view.addSubview(navigationStackView)
         self.view.addSubview(mainStackView)
-        mainStackView.snp.makeConstraints {
-            $0.edges.equalTo(self.view.safeAreaLayoutGuide)
+        
+        navigationStackView.snp.makeConstraints {
+            $0.top.equalTo(self.view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalTo(self.view.safeAreaLayoutGuide).inset(20)
+            $0.height.equalTo(40)
         }
-        setNavigationBar()
+        
+        networkStackView.snp.makeConstraints {
+            $0.width.equalToSuperview().multipliedBy(0.1)
+        }
+        
+        stateImage.snp.makeConstraints {
+            $0.width.equalTo(13)
+            $0.height.equalTo(13)
+        }
+        
+        addButton.snp.makeConstraints {
+            $0.width.equalToSuperview().multipliedBy(0.1)
+        }
+        
+        mainStackView.snp.makeConstraints {
+            $0.top.equalTo(navigationStackView.snp.bottom).offset(15)
+            $0.leading.trailing.bottom.equalTo(self.view.safeAreaLayoutGuide)
+        }
         bindView()
-    }
-    
-    private func setNavigationBar() {
-        self.title = "Project Manger"
     }
     
     private func bindView() {
@@ -198,7 +214,53 @@ final class MainViewController: UIViewController {
     }
     
     // MARK: - UI Components
-    private lazy var addButton = UIBarButtonItem(systemItem: .add)
+    private lazy var navigationStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [networkStackView, titleLabel, addButton])
+        stackView.alignment = .bottom
+        
+        return stackView
+    }()
+    
+    private lazy var networkStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [networkLabel, stateImage, UILabel()])
+        stackView.alignment = .center
+        return stackView
+    }()
+    
+    private lazy var networkLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .left
+        label.font = UIFont.systemFont(ofSize: 15, weight: .light)
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        label.text = "Offline"
+        
+        return label
+    }()
+    
+    private lazy var stateImage: UIImageView = {
+        let imageView = UIImageView(image: UIImage(systemName: "circle.fill"))
+        imageView.tintColor = .red
+        imageView.setContentHuggingPriority(.required, for: .horizontal)
+        return imageView
+    }()
+    
+    
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.font = UIFont.systemFont(ofSize: 20, weight: .bold)
+        label.text = "Project Manager"
+        
+        return label
+    }()
+    
+    private lazy var addButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "plus"), for: .normal)
+        button.setPreferredSymbolConfiguration(.init(pointSize: 25, weight: .regular, scale: .default), forImageIn: .normal)
+        button.contentHorizontalAlignment = .right
+        return button
+    }()
     
     private lazy var mainStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews:[listStackView(headerView: todoHeaderView,

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
@@ -48,7 +48,7 @@ final class MainViewController: UIViewController {
             $0.height.equalTo(40)
         }
         
-        networkStackView.snp.makeConstraints {
+        historyButton.snp.makeConstraints {
             $0.width.equalToSuperview().multipliedBy(0.1)
         }
         
@@ -62,7 +62,7 @@ final class MainViewController: UIViewController {
         }
         
         mainStackView.snp.makeConstraints {
-            $0.top.equalTo(navigationStackView.snp.bottom).offset(15)
+            $0.top.equalTo(navigationStackView.snp.bottom).offset(5)
             $0.leading.trailing.bottom.equalTo(self.view.safeAreaLayoutGuide)
         }
         bindView()
@@ -221,15 +221,25 @@ final class MainViewController: UIViewController {
     
     // MARK: - UI Components
     private lazy var navigationStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [networkStackView, titleLabel, addButton])
-        stackView.alignment = .bottom
+        let stackView = UIStackView(arrangedSubviews: [historyButton, titleLabel, addButton])
+        stackView.alignment = .center
         
         return stackView
     }()
     
+    private lazy var historyButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("History", for: .normal)
+        button.setTitleColor(UIColor.systemBlue, for: .normal)
+        button.contentHorizontalAlignment = .leading
+        
+        return button
+    }()
+    
     private lazy var networkStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [networkLabel, stateImage, UILabel()])
-        stackView.alignment = .center
+        stackView.alignment = .bottom
+        
         return stackView
     }()
     

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
@@ -100,7 +100,14 @@ final class MainViewController: UIViewController {
         .disposed(by: disposebag)
         
         viewModel.showHistoryView.bind(onNext: { [weak self] in
-            print($0)
+            guard let self = self else {
+                return
+            }
+            
+            let historyVC = self.container.makeHistoryViewController(sourceView: self.view,
+                                                                     bounds: self.historyButton.bounds)
+            self.present(historyVC, animated: true)
+            print($0) // 추후 삭제 예정
         }).disposed(by: disposebag)
         
         viewModel.showErrorAlert.bind(onNext: { [weak self] in

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
@@ -41,11 +41,11 @@ final class MainViewController: UIViewController {
         self.view.backgroundColor = .systemGray5
         self.view.addSubview(navigationStackView)
         self.view.addSubview(mainStackView)
+        self.view.addSubview(bottomStackView)
         
         navigationStackView.snp.makeConstraints {
             $0.top.equalTo(self.view.safeAreaLayoutGuide)
             $0.leading.trailing.equalTo(self.view.safeAreaLayoutGuide).inset(20)
-            $0.height.equalTo(40)
         }
         
         historyButton.snp.makeConstraints {
@@ -62,9 +62,16 @@ final class MainViewController: UIViewController {
         }
         
         mainStackView.snp.makeConstraints {
-            $0.top.equalTo(navigationStackView.snp.bottom).offset(5)
-            $0.leading.trailing.bottom.equalTo(self.view.safeAreaLayoutGuide)
+            $0.top.equalTo(navigationStackView.snp.bottom).inset(-5)
+            $0.leading.trailing.equalTo(self.view.safeAreaLayoutGuide)
+            $0.bottom.equalTo(bottomStackView.snp.top).inset(-20)
         }
+        
+        bottomStackView.snp.makeConstraints {
+            $0.bottom.equalTo(self.view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalTo(self.view.safeAreaLayoutGuide).inset(20)
+        }
+        
         bindView()
     }
     
@@ -289,9 +296,15 @@ final class MainViewController: UIViewController {
     }
     
     // MARK: - bottomStackView
+    private lazy var bottomStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [networkStackView, rightButtonStackView])
+        stackView.distribution = .equalSpacing
+        
+        return stackView
+    }()
+    
     private lazy var networkStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [networkLabel, stateImage, UILabel()])
-        stackView.alignment = .bottom
         
         return stackView
     }()
@@ -310,6 +323,31 @@ final class MainViewController: UIViewController {
         let imageView = UIImageView(image: UIImage(systemName: "circle.fill"))
         imageView.tintColor = .red
         imageView.setContentHuggingPriority(.required, for: .horizontal)
+        
         return imageView
+    }()
+    
+    private lazy var rightButtonStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [undoButton, redoButton])
+        stackView.distribution = .fillEqually
+        stackView.spacing = 20
+        
+        return stackView
+    }()
+    
+    private lazy var undoButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("Undo", for: .normal)
+        button.setTitleColor(UIColor.systemBlue, for: .normal)
+        
+        return button
+    }()
+    
+    private lazy var redoButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("Redo", for: .normal)
+        button.setTitleColor(UIColor.systemBlue, for: .normal)
+        
+        return button
     }()
 }

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
@@ -105,9 +105,9 @@ final class MainViewController: UIViewController {
             }
             
             let historyVC = self.container.makeHistoryViewController(sourceView: self.view,
-                                                                     bounds: self.historyButton.bounds)
+                                                                     bounds: self.historyButton.bounds,
+                                                                     history: $0)
             self.present(historyVC, animated: true)
-            print($0) // 추후 삭제 예정
         }).disposed(by: disposebag)
         
         viewModel.showErrorAlert.bind(onNext: { [weak self] in

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
@@ -220,6 +220,8 @@ final class MainViewController: UIViewController {
     }
     
     // MARK: - UI Components
+    
+    // MARK: - navigationStackView
     private lazy var navigationStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [historyButton, titleLabel, addButton])
         stackView.alignment = .center
@@ -235,31 +237,6 @@ final class MainViewController: UIViewController {
         
         return button
     }()
-    
-    private lazy var networkStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [networkLabel, stateImage, UILabel()])
-        stackView.alignment = .bottom
-        
-        return stackView
-    }()
-    
-    private lazy var networkLabel: UILabel = {
-        let label = UILabel()
-        label.textAlignment = .left
-        label.font = UIFont.systemFont(ofSize: 15, weight: .light)
-        label.setContentHuggingPriority(.required, for: .horizontal)
-        label.text = "Offline"
-        
-        return label
-    }()
-    
-    private lazy var stateImage: UIImageView = {
-        let imageView = UIImageView(image: UIImage(systemName: "circle.fill"))
-        imageView.tintColor = .red
-        imageView.setContentHuggingPriority(.required, for: .horizontal)
-        return imageView
-    }()
-    
     
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
@@ -278,6 +255,7 @@ final class MainViewController: UIViewController {
         return button
     }()
     
+    // MARK: - mainStackView
     private lazy var mainStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews:[listStackView(headerView: todoHeaderView,
                                                                     tableView: todoTableView),
@@ -309,4 +287,29 @@ final class MainViewController: UIViewController {
         
         return tableView
     }
+    
+    // MARK: - bottomStackView
+    private lazy var networkStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [networkLabel, stateImage, UILabel()])
+        stackView.alignment = .bottom
+        
+        return stackView
+    }()
+    
+    private lazy var networkLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .left
+        label.font = UIFont.systemFont(ofSize: 15, weight: .light)
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        label.text = "Offline"
+        
+        return label
+    }()
+    
+    private lazy var stateImage: UIImageView = {
+        let imageView = UIImageView(image: UIImage(systemName: "circle.fill"))
+        imageView.tintColor = .red
+        imageView.setContentHuggingPriority(.required, for: .horizontal)
+        return imageView
+    }()
 }

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
@@ -95,6 +95,12 @@ final class MainViewController: UIViewController {
             self?.showNetworkErrorAlert()
         })
         .disposed(by: disposebag)
+        
+        viewModel.isConnectedInternet.bind(onNext: { [weak self] in
+            self?.networkLabel.text = $0 ? "Online" : "Offline"
+            self?.stateImage.tintColor = $0 ? .green : .red
+        })
+        .disposed(by: disposebag)
     }
     
     private func bindTableView() {

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
@@ -84,6 +84,12 @@ final class MainViewController: UIViewController {
             })
             .disposed(by: disposebag)
         
+        historyButton.rx.tap
+            .bind(onNext: { [weak self] in
+                self?.viewModel.touchHistoryButton()
+            })
+            .disposed(by: disposebag)
+        
         viewModel.showAddView.bind(onNext: { [weak self] in
             guard let self = self else {
                 return
@@ -92,6 +98,8 @@ final class MainViewController: UIViewController {
             self.present(self.container.makeAddViewController(), animated: true)
         })
         .disposed(by: disposebag)
+        
+        viewModel.showHistoryView.bind(onNext: {}).disposed(by: disposebag)
         
         viewModel.showErrorAlert.bind(onNext: { [weak self] in
             self?.showErrorAlert(messege: $0)

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
@@ -99,7 +99,9 @@ final class MainViewController: UIViewController {
         })
         .disposed(by: disposebag)
         
-        viewModel.showHistoryView.bind(onNext: {}).disposed(by: disposebag)
+        viewModel.showHistoryView.bind(onNext: { [weak self] in
+            print($0)
+        }).disposed(by: disposebag)
         
         viewModel.showErrorAlert.bind(onNext: { [weak self] in
             self?.showErrorAlert(messege: $0)

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewController.swift
@@ -111,7 +111,7 @@ final class MainViewController: UIViewController {
         }).disposed(by: disposebag)
         
         viewModel.showErrorAlert.bind(onNext: { [weak self] in
-            self?.showErrorAlert(messege: $0)
+            self?.showErrorAlert(message: $0)
         })
         .disposed(by: disposebag)
         

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
@@ -21,6 +21,7 @@ protocol MainViewModelOutput {
     var showAddView: PublishRelay<Void> { get }
     var showEditView: PublishRelay<ListItem> { get }
     var showErrorAlert: PublishRelay<String?> { get }
+    var showNetworkErrorAlert: PublishRelay<Void> { get }
 }
 
 protocol MainViewModelInput {
@@ -56,8 +57,8 @@ final class MainViewModel: MainViewModelInOut {
             switch result {
             case .success():
                 UserDefaults.standard.set(true, forKey: "lunchedBefore")
-            case .failure(let error):
-                self.showErrorAlert.accept(error.errorDescription)
+            case .failure(_):
+                self.showNetworkErrorAlert.accept(())
             }
             print("activity indicator 종료")
         }
@@ -77,6 +78,7 @@ final class MainViewModel: MainViewModelInOut {
     var showAddView = PublishRelay<Void>()
     var showEditView = PublishRelay<ListItem>()
     var showErrorAlert = PublishRelay<String?>()
+    var showNetworkErrorAlert = PublishRelay<Void>()
 }
 
 //MARK: - input

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
@@ -20,7 +20,7 @@ protocol MainViewModelOutput {
     func listCount(_ type: ListType) -> Driver<String>
     
     var showAddView: PublishRelay<Void> { get }
-    var showHistoryView: PublishRelay<Void> { get }
+    var showHistoryView: PublishRelay<[History]> { get }
     var showEditView: PublishRelay<ListItem> { get }
     var showErrorAlert: PublishRelay<String?> { get }
     var showNetworkErrorAlert: PublishRelay<Void> { get }
@@ -101,7 +101,7 @@ final class MainViewModel: MainViewModelInOut {
     }
     
     let showAddView = PublishRelay<Void>()
-    let showHistoryView = PublishRelay<Void>()
+    let showHistoryView = PublishRelay<[History]>()
     let showEditView = PublishRelay<ListItem>()
     let showErrorAlert = PublishRelay<String?>()
     let showNetworkErrorAlert = PublishRelay<Void>()
@@ -119,7 +119,7 @@ extension MainViewModel {
     }
     
     func touchHistoryButton() {
-        print("history")
+        showHistoryView.accept(storage.readHistory().reversed())
     }
     
     func touchCell(index: Int, type: ListType) {

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
@@ -78,7 +78,6 @@ final class MainViewModel: MainViewModelInOut {
     }
     
     private func setList() {
-        print("activity indicator 시작")
         storage.setList { result in
             switch result {
             case .success():
@@ -86,7 +85,6 @@ final class MainViewModel: MainViewModelInOut {
             case .failure(_):
                 self.showNetworkErrorAlert.accept(StorageError.networkError)
             }
-            print("activity indicator 종료")
         }
     }
     

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
@@ -129,7 +129,8 @@ extension MainViewModel {
     
     func deleteCell(index: Int, type: ListType) {
         do {
-            try storage.deleteItem(index: index, type: type)
+            let item = storage.selectItem(index: index, type: type)
+            try storage.deleteItem(listItem: item)
         } catch {
             guard let error = error as? StorageError else {
                 showErrorAlert.accept(nil)
@@ -142,7 +143,8 @@ extension MainViewModel {
     
     func changeItemType(index: Int, type: ListType, to destination: ListType) {
         do {
-            try storage.changeItemType(index: index, type: type, destination: destination)
+            let item = storage.selectItem(index: index, type: type)
+            try storage.changeItemType(listItem: item, destination: destination)
         } catch {
             guard let error = error as? StorageError else {
                 showErrorAlert.accept(nil)

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
@@ -131,6 +131,7 @@ extension MainViewModel {
         do {
             let item = storage.selectItem(index: index, type: type)
             try storage.deleteItem(listItem: item)
+            try storage.makeHistory(title: "Removed '\(item.title)'.")
         } catch {
             guard let error = error as? StorageError else {
                 showErrorAlert.accept(nil)
@@ -145,6 +146,7 @@ extension MainViewModel {
         do {
             let item = storage.selectItem(index: index, type: type)
             try storage.changeItemType(listItem: item, destination: destination)
+            try storage.makeHistory(title: "Moved '\(item.title)' from \(type.title) to \(destination.title).")
         } catch {
             guard let error = error as? StorageError else {
                 showErrorAlert.accept(nil)

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
@@ -23,7 +23,7 @@ protocol MainViewModelOutput {
     var showHistoryView: PublishRelay<[History]> { get }
     var showEditView: PublishRelay<ListItem> { get }
     var showErrorAlert: PublishRelay<String?> { get }
-    var showNetworkErrorAlert: PublishRelay<Void> { get }
+    var showNetworkErrorAlert: PublishRelay<StorageError> { get }
     var isConnectedInternet: PublishRelay<Bool> { get }
 }
 
@@ -69,7 +69,7 @@ final class MainViewModel: MainViewModelInOut {
             if path.status != .satisfied  {
                 DispatchQueue.main.async {
                     if UserDefaults.standard.bool(forKey: "lunchedBefore") == false {
-                        self.showNetworkErrorAlert.accept(())
+                        self.showNetworkErrorAlert.accept(StorageError.networkError)
                     }
                     self.isConnectedInternet.accept(false)
                 }
@@ -84,7 +84,7 @@ final class MainViewModel: MainViewModelInOut {
             case .success():
                 UserDefaults.standard.set(true, forKey: "lunchedBefore")
             case .failure(_):
-                self.showNetworkErrorAlert.accept(())
+                self.showNetworkErrorAlert.accept(StorageError.networkError)
             }
             print("activity indicator 종료")
         }
@@ -105,7 +105,7 @@ final class MainViewModel: MainViewModelInOut {
     let showHistoryView = PublishRelay<[History]>()
     let showEditView = PublishRelay<ListItem>()
     let showErrorAlert = PublishRelay<String?>()
-    let showNetworkErrorAlert = PublishRelay<Void>()
+    let showNetworkErrorAlert = PublishRelay<StorageError>()
     let isConnectedInternet = PublishRelay<Bool>()
 }
 

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
@@ -53,7 +53,6 @@ final class MainViewModel: MainViewModelInOut {
         checkNetwork()
         if UserDefaults.standard.bool(forKey: "lunchedBefore") == false {
             setList()
-            UserDefaults.standard.set(true, forKey: "lunchedBefore")
         }
     }
     

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
@@ -20,7 +20,7 @@ protocol MainViewModelOutput {
     
     var showAddView: PublishRelay<Void> { get }
     var showEditView: PublishRelay<ListItem> { get }
-    var showErrorAlert: PublishRelay<String> { get }
+    var showErrorAlert: PublishRelay<String?> { get }
 }
 
 protocol MainViewModelInput {
@@ -59,7 +59,7 @@ final class MainViewModel: MainViewModelInOut {
     
     var showAddView = PublishRelay<Void>()
     var showEditView = PublishRelay<ListItem>()
-    var showErrorAlert = PublishRelay<String>()
+    var showErrorAlert = PublishRelay<String?>()
 }
 
 //MARK: - input
@@ -82,6 +82,7 @@ extension MainViewModel {
             try storage.deleteItem(index: index, type: type)
         } catch {
             guard let error = error as? StorageError else {
+                showErrorAlert.accept(nil)
                 return
             }
             
@@ -94,6 +95,7 @@ extension MainViewModel {
             try storage.changeItemType(index: index, type: type, destination: destination)
         } catch {
             guard let error = error as? StorageError else {
+                showErrorAlert.accept(nil)
                 return
             }
             

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
@@ -61,8 +61,13 @@ final class MainViewModel: MainViewModelInOut {
                 DispatchQueue.main.async {
                     self.isConnectedInternet.accept(true)
                 }
-            } else {
+            }
+            
+            if path.status != .satisfied  {
                 DispatchQueue.main.async {
+                    if UserDefaults.standard.bool(forKey: "lunchedBefore") == false {
+                        self.showNetworkErrorAlert.accept(())
+                    }
                     self.isConnectedInternet.accept(false)
                 }
             }

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
@@ -44,6 +44,23 @@ final class MainViewModel: MainViewModelInOut {
         todoList = storage.todoList.asDriver(onErrorJustReturn: [])
         doingList = storage.doingList.asDriver(onErrorJustReturn: [])
         doneList = storage.doneList.asDriver(onErrorJustReturn: [])
+        
+        if UserDefaults.standard.bool(forKey: "lunchedBefore") == false {
+            setList()
+        }
+    }
+    
+    private func setList() {
+        print("activity indicator 시작")
+        storage.setList { result in
+            switch result {
+            case .success():
+                UserDefaults.standard.set(true, forKey: "lunchedBefore")
+            case .failure(let error):
+                self.showErrorAlert.accept(error.errorDescription)
+            }
+            print("activity indicator 종료")
+        }
     }
     
     func listCount(_ type: ListType) -> Driver<String> {

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
@@ -20,6 +20,7 @@ protocol MainViewModelOutput {
     func listCount(_ type: ListType) -> Driver<String>
     
     var showAddView: PublishRelay<Void> { get }
+    var showHistoryView: PublishRelay<Void> { get }
     var showEditView: PublishRelay<ListItem> { get }
     var showErrorAlert: PublishRelay<String?> { get }
     var showNetworkErrorAlert: PublishRelay<Void> { get }
@@ -28,6 +29,7 @@ protocol MainViewModelOutput {
 
 protocol MainViewModelInput {
     func touchAddButton()
+    func touchHistoryButton()
     func touchCell(index: Int, type: ListType)
     func deleteCell(index: Int, type: ListType)
     func changeItemType(index: Int, type: ListType, to: ListType)
@@ -99,6 +101,7 @@ final class MainViewModel: MainViewModelInOut {
     }
     
     let showAddView = PublishRelay<Void>()
+    let showHistoryView = PublishRelay<Void>()
     let showEditView = PublishRelay<ListItem>()
     let showErrorAlert = PublishRelay<String?>()
     let showNetworkErrorAlert = PublishRelay<Void>()
@@ -113,6 +116,10 @@ extension MainViewModel {
     
     func touchAddButton() {
         showAddView.accept(())
+    }
+    
+    func touchHistoryButton() {
+        print("history")
     }
     
     func touchCell(index: Int, type: ListType) {

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
@@ -32,7 +32,7 @@ protocol MainViewModelInput {
 }
 
 final class MainViewModel: MainViewModelInOut {
-    private var storage: AppStoregeable
+    private let storage: AppStoregeable
 
 //MARK: - output
     let todoList: Driver<[ListItem]>
@@ -75,10 +75,10 @@ final class MainViewModel: MainViewModelInOut {
         }
     }
     
-    var showAddView = PublishRelay<Void>()
-    var showEditView = PublishRelay<ListItem>()
-    var showErrorAlert = PublishRelay<String?>()
-    var showNetworkErrorAlert = PublishRelay<Void>()
+    let showAddView = PublishRelay<Void>()
+    let showEditView = PublishRelay<ListItem>()
+    let showErrorAlert = PublishRelay<String?>()
+    let showNetworkErrorAlert = PublishRelay<Void>()
 }
 
 //MARK: - input

--- a/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
+++ b/ProjectManager/ProjectManager/Scene/Main/MainViewModel.swift
@@ -53,6 +53,7 @@ final class MainViewModel: MainViewModelInOut {
         checkNetwork()
         if UserDefaults.standard.bool(forKey: "lunchedBefore") == false {
             setList()
+            UserDefaults.standard.set(true, forKey: "lunchedBefore")
         }
     }
     

--- a/ProjectManager/ProjectManager/SceneDelegate.swift
+++ b/ProjectManager/ProjectManager/SceneDelegate.swift
@@ -7,8 +7,7 @@
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-    private let container = Container(storage: AppStorage(localStorage: LocalStorageManager(),
-                                                          networkStorage: NetworkStorageManager()))
+    private let container = Container(storage: AppStorage(LocalStorageManager(NetworkStorageManager())))
     var window: UIWindow?
 
 

--- a/ProjectManager/ProjectManager/SceneDelegate.swift
+++ b/ProjectManager/ProjectManager/SceneDelegate.swift
@@ -4,19 +4,30 @@
 //  Copyright © yagom. All rights reserved.
 // 
 
-import UIKit
+import RealmSwift
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-    private let container = Container(storage: AppStorage(LocalStorageManager(NetworkStorageManager())))
     var window: UIWindow?
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
+        guard let realm = try? Realm() else {
+            showErrorViewController()
+            return
+        }
         
+        let container = Container(storage: AppStorage(LocalStorageManager(networkStorageManager: NetworkStorageManager(), realm: realm)))
         window?.rootViewController = container.makeMainViewController()
         window?.makeKeyAndVisible()
+    }
+    
+    private func showErrorViewController() {
+        window?.rootViewController = UIViewController()
+        window?.makeKeyAndVisible()
+        window?.rootViewController?
+            .showExitAlert(message: StorageError.localStorageError.errorDescription)
     }
 }
 

--- a/ProjectManager/ProjectManager/SceneDelegate.swift
+++ b/ProjectManager/ProjectManager/SceneDelegate.swift
@@ -14,9 +14,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let navigationController = UINavigationController(rootViewController: container.makeMainViewController())
         
-        window?.rootViewController = navigationController
+        window?.rootViewController = container.makeMainViewController()
         window?.makeKeyAndVisible()
     }
 }

--- a/ProjectManager/ProjectManager/SceneDelegate.swift
+++ b/ProjectManager/ProjectManager/SceneDelegate.swift
@@ -7,7 +7,8 @@
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-    private let container = Container(storage: AppStorage(LocalStorageManager()))
+    private let container = Container(storage: AppStorage(localStorage: LocalStorageManager(),
+                                                          networkStorage: NetworkStorageManager()))
     var window: UIWindow?
 
 

--- a/ProjectManager/ProjectManager/Storage/AppStorage.swift
+++ b/ProjectManager/ProjectManager/Storage/AppStorage.swift
@@ -11,6 +11,7 @@ protocol AppStoregeable {
     var todoList: BehaviorRelay<[ListItem]> { get }
     var doingList: BehaviorRelay<[ListItem]> { get }
     var doneList: BehaviorRelay<[ListItem]> { get }
+    func setList(_ completion: @escaping (Result<(), StorageError>) -> Void)
     func creatItem(listItem: ListItem) throws
     func updateItem(listItem: ListItem) throws
     func selectItem(index: Int, type: ListType) -> ListItem
@@ -31,6 +32,21 @@ final class AppStorage: AppStoregeable {
         self.doingList = BehaviorRelay<[ListItem]>(value: localStorage.readList(.doing))
         self.doneList = BehaviorRelay<[ListItem]>(value: localStorage.readList(.done))
     }
+    
+    func setList(_ completion: @escaping (Result<Void, StorageError>) -> Void) {
+        localStorage.setList { result in
+            switch result {
+            case .success():
+                self.todoList.accept(self.localStorage.readList(.todo))
+                self.doingList.accept(self.localStorage.readList(.doing))
+                self.doneList.accept(self.localStorage.readList(.done))
+                completion(.success(()))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+    
     private func selectList(_ type: ListType) -> BehaviorRelay<[ListItem]> {
         switch type {
         case .todo:

--- a/ProjectManager/ProjectManager/Storage/AppStorage.swift
+++ b/ProjectManager/ProjectManager/Storage/AppStorage.swift
@@ -15,8 +15,8 @@ protocol AppStoregeable {
     func creatItem(listItem: ListItem) throws
     func updateItem(listItem: ListItem) throws
     func selectItem(index: Int, type: ListType) -> ListItem
-    func deleteItem(index: Int, type: ListType) throws
-    func changeItemType(index: Int, type: ListType, destination: ListType) throws
+    func deleteItem(listItem: ListItem) throws
+    func changeItemType(listItem: ListItem, destination: ListType) throws
 }
 
 final class AppStorage: AppStoregeable {
@@ -72,7 +72,7 @@ final class AppStorage: AppStoregeable {
     func selectItem(index: Int, type: ListType) -> ListItem {
         return selectList(type).value[index]
     }
-    
+
     func updateItem(listItem: ListItem) throws {
         do {
             try localStorage.updateItem(listItem)
@@ -83,23 +83,21 @@ final class AppStorage: AppStoregeable {
         }
     }
     
-    func deleteItem(index: Int, type: ListType) throws {
-        let item = selectItem(index: index, type: type)
-        
+    func deleteItem(listItem: ListItem) throws {
         do {
-            try localStorage.deleteItem(item)
-            let nweList = localStorage.readList(item.type)
-            selectList(item.type).accept(nweList)
+            try localStorage.deleteItem(listItem)
+            let nweList = localStorage.readList(listItem.type)
+            selectList(listItem.type).accept(nweList)
+            
         } catch {
             throw StorageError.deleteError
         }
     }
-    
-    func changeItemType(index: Int, type: ListType, destination: ListType) throws {
-        var item = selectItem(index: index, type: type)
-        
+
+    func changeItemType(listItem: ListItem, destination: ListType) throws {
+        var item = listItem
         do {
-            try deleteItem(index: index, type: type)
+            try deleteItem(listItem: item)
         } catch {
             throw StorageError.updateError
         }

--- a/ProjectManager/ProjectManager/Storage/AppStorage.swift
+++ b/ProjectManager/ProjectManager/Storage/AppStorage.swift
@@ -43,18 +43,10 @@ final class AppStorage: AppStoregeable {
     }
     
     func creatItem(listItem: ListItem) throws {
-        var createError: StorageError?
-        
-        localStorage.createItem(listItem) { [weak self] result in
-            switch result {
-            case .success(let list):
-                self?.selectList(listItem.type).accept(list)
-            case .failure(let error):
-                createError = error
-            }
-        }
-        
-        if createError != nil {
+        do {
+            let list = try localStorage.createItem(listItem)
+            selectList(listItem.type).accept(list)
+        } catch {
             throw StorageError.creatError
         }
     }
@@ -64,36 +56,21 @@ final class AppStorage: AppStoregeable {
     }
     
     func updateItem(listItem: ListItem) throws {
-        var updateError: StorageError?
-        
-        localStorage.updateItem(listItem) { [weak self] result in
-            switch result {
-            case .success(let list):
-                self?.selectList(listItem.type).accept(list)
-            case .failure(let error):
-                updateError = error
-            }
-        }
-        
-        if updateError != nil {
+        do {
+            let list = try localStorage.updateItem(listItem)
+            selectList(listItem.type).accept(list)
+        } catch {
             throw StorageError.updateError
         }
     }
     
     func deleteItem(index: Int, type: ListType) throws {
         let item = selectItem(index: index, type: type)
-        var deleteError: StorageError?
         
-        localStorage.deleteItem(item) { [weak self] result in
-            switch result {
-            case .success(let list):
-                self?.selectList(item.type).accept(list)
-            case .failure(let error):
-                deleteError = error
-            }
-        }
-        
-        if deleteError != nil {
+        do {
+            let list = try localStorage.deleteItem(item)
+            selectList(item.type).accept(list)
+        } catch {
             throw StorageError.deleteError
         }
     }

--- a/ProjectManager/ProjectManager/Storage/AppStorage.swift
+++ b/ProjectManager/ProjectManager/Storage/AppStorage.swift
@@ -12,6 +12,7 @@ protocol AppStoregeable {
     var doingList: BehaviorRelay<[ListItem]> { get }
     var doneList: BehaviorRelay<[ListItem]> { get }
     func setList(_ completion: @escaping (Result<(), StorageError>) -> Void)
+    func readHistory() -> [History]
     func creatItem(listItem: ListItem) throws
     func updateItem(listItem: ListItem) throws
     func selectItem(index: Int, type: ListType) -> ListItem
@@ -65,6 +66,10 @@ final class AppStorage: AppStoregeable {
         } catch {
             throw StorageError.historyError
         }
+    }
+    
+    func readHistory() -> [History] {
+        return localStorage.readHistory()
     }
     
     func creatItem(listItem: ListItem) throws {

--- a/ProjectManager/ProjectManager/Storage/AppStorage.swift
+++ b/ProjectManager/ProjectManager/Storage/AppStorage.swift
@@ -17,6 +17,7 @@ protocol AppStoregeable {
     func selectItem(index: Int, type: ListType) -> ListItem
     func deleteItem(listItem: ListItem) throws
     func changeItemType(listItem: ListItem, destination: ListType) throws
+    func makeHistory(title: String) throws
 }
 
 final class AppStorage: AppStoregeable {
@@ -55,6 +56,14 @@ final class AppStorage: AppStoregeable {
             return doingList
         case .done:
             return doneList
+        }
+    }
+    
+    func makeHistory(title: String) throws {
+        do {
+            try localStorage.addHistory(title: title)
+        } catch {
+            throw StorageError.historyError
         }
     }
     

--- a/ProjectManager/ProjectManager/Storage/AppStorage.swift
+++ b/ProjectManager/ProjectManager/Storage/AppStorage.swift
@@ -20,13 +20,15 @@ protocol AppStoregeable {
 
 final class AppStorage: AppStoregeable {
     private let localStorage: LocalStorageManagerable
+    private let networkStorage: NetworkStorageManagerable
     
     let todoList: BehaviorRelay<[ListItem]>
     let doingList: BehaviorRelay<[ListItem]>
     let doneList: BehaviorRelay<[ListItem]>
     
-    init(_ localStorage: LocalStorageManagerable) {
+    init(localStorage: LocalStorageManagerable, networkStorage: NetworkStorageManagerable) {
         self.localStorage = localStorage
+        self.networkStorage = networkStorage
         self.todoList = BehaviorRelay<[ListItem]>(value: localStorage.readList(.todo))
         self.doingList = BehaviorRelay<[ListItem]>(value: localStorage.readList(.doing))
         self.doneList = BehaviorRelay<[ListItem]>(value: localStorage.readList(.done))
@@ -46,6 +48,7 @@ final class AppStorage: AppStoregeable {
         do {
             let list = try localStorage.createItem(listItem)
             selectList(listItem.type).accept(list)
+            
         } catch {
             throw StorageError.creatError
         }

--- a/ProjectManager/ProjectManager/Storage/AppStorage.swift
+++ b/ProjectManager/ProjectManager/Storage/AppStorage.swift
@@ -44,8 +44,9 @@ final class AppStorage: AppStoregeable {
     
     func creatItem(listItem: ListItem) throws {
         do {
-            let list = try localStorage.createItem(listItem)
-            selectList(listItem.type).accept(list)
+            try localStorage.createItem(listItem)
+            let newList = localStorage.readList(listItem.type)
+            selectList(listItem.type).accept(newList)
             
         } catch {
             throw StorageError.creatError
@@ -58,8 +59,9 @@ final class AppStorage: AppStoregeable {
     
     func updateItem(listItem: ListItem) throws {
         do {
-            let list = try localStorage.updateItem(listItem)
-            selectList(listItem.type).accept(list)
+            try localStorage.updateItem(listItem)
+            let nweList = localStorage.readList(listItem.type)
+            selectList(listItem.type).accept(nweList)
         } catch {
             throw StorageError.updateError
         }
@@ -69,8 +71,9 @@ final class AppStorage: AppStoregeable {
         let item = selectItem(index: index, type: type)
         
         do {
-            let list = try localStorage.deleteItem(item)
-            selectList(item.type).accept(list)
+            try localStorage.deleteItem(item)
+            let nweList = localStorage.readList(item.type)
+            selectList(item.type).accept(nweList)
         } catch {
             throw StorageError.deleteError
         }

--- a/ProjectManager/ProjectManager/Storage/AppStorage.swift
+++ b/ProjectManager/ProjectManager/Storage/AppStorage.swift
@@ -20,15 +20,13 @@ protocol AppStoregeable {
 
 final class AppStorage: AppStoregeable {
     private let localStorage: LocalStorageManagerable
-    private let networkStorage: NetworkStorageManagerable
     
     let todoList: BehaviorRelay<[ListItem]>
     let doingList: BehaviorRelay<[ListItem]>
     let doneList: BehaviorRelay<[ListItem]>
     
-    init(localStorage: LocalStorageManagerable, networkStorage: NetworkStorageManagerable) {
+    init(_ localStorage: LocalStorageManagerable) {
         self.localStorage = localStorage
-        self.networkStorage = networkStorage
         self.todoList = BehaviorRelay<[ListItem]>(value: localStorage.readList(.todo))
         self.doingList = BehaviorRelay<[ListItem]>(value: localStorage.readList(.doing))
         self.doneList = BehaviorRelay<[ListItem]>(value: localStorage.readList(.done))

--- a/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
+++ b/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
@@ -22,6 +22,17 @@ final class LocalStorageManager: LocalStorageManagerable {
         self.networkStorageManager = networkStorageManager
     }
     
+    private func convertedItem(_ item: ListItem) -> ListItemDTO {
+            let itemModel = ListItemDTO()
+            itemModel.title = item.title
+            itemModel.body = item.body
+            itemModel.deadline = item.deadline
+            itemModel.type = item.type.rawValue
+            itemModel.id = item.id
+            
+            return itemModel
+    }
+    
     private func selectListModel(_ type: ListType) -> List<ListItemDTO> {
         guard let realm = try? Realm() else {
             return List<ListItemDTO>()
@@ -62,17 +73,17 @@ final class LocalStorageManager: LocalStorageManagerable {
         do {
             if realm.objects(LocalStorage.self).isEmpty {
                 let listModel = LocalStorage()
-                listModel.todoList.append(item.convertedItem)
+                listModel.todoList.append(convertedItem(item))
                 
                 try realm.write {
                     realm.add(listModel)
                 }
             } else {
                 try realm.write {
-                    selectListModel(item.type).append(item.convertedItem)
+                    selectListModel(item.type).append(convertedItem(item))
                 }
             }
-            networkStorageManager.create(item.convertedItem)
+            networkStorageManager.create(convertedItem(item))
         } catch {
             throw StorageError.creatError
         }
@@ -90,7 +101,7 @@ final class LocalStorageManager: LocalStorageManagerable {
                 itemModel?.deadline = item.deadline
                 itemModel?.body = item.body
             }
-            networkStorageManager.updateItem(item.convertedItem)
+            networkStorageManager.updateItem(convertedItem(item))
         } catch {
             throw StorageError.updateError
         }
@@ -108,7 +119,7 @@ final class LocalStorageManager: LocalStorageManagerable {
             try realm?.write {
                 realm?.delete(itemModel)
             }
-            networkStorageManager.deleteItem(item.convertedItem)
+            networkStorageManager.deleteItem(convertedItem(item))
         } catch {
             throw StorageError.deleteError
         }

--- a/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
+++ b/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
@@ -107,7 +107,12 @@ final class LocalStorageManager: LocalStorageManagerable {
                 let history = History()
                 history.title = title
                 
-                listModel.history.append(history)
+                let historyStorage = listModel.history
+                historyStorage.append(history)
+                
+                if historyStorage.count > 15 {
+                    historyStorage.removeFirst()
+                }
             }
         } catch{
             throw StorageError.historyError

--- a/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
+++ b/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
@@ -15,7 +15,12 @@ protocol LocalStorageManagerable {
 }
 
 final class LocalStorageManager: LocalStorageManagerable {
+    private let networkStorageManager: NetworkStorageManagerable
     private let realm = try? Realm()
+    
+    init(_ networkStorageManager: NetworkStorageManagerable) {
+        self.networkStorageManager = networkStorageManager
+    }
     
     private func selectListModel(_ type: ListType) -> List<ListItemDTO> {
         guard let realm = try? Realm() else {

--- a/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
+++ b/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
@@ -30,12 +30,17 @@ final class LocalStorageManager: LocalStorageManagerable {
         networkStorageManager.read { result in
             switch result {
             case .success(let list):
-                list.forEach {
-                    do {
-                        try self.createItem($0)
-                    } catch {
-                        completion(.failure(StorageError.readError))
+                do {
+                    try self.deleteAll()
+                    list.forEach {
+                        do {
+                            try self.createItem($0)
+                        } catch {
+                            completion(.failure(StorageError.readError))
+                        }
                     }
+                } catch {
+                    completion(.failure(StorageError.deleteError))
                 }
                 completion(.success(()))
             case .failure(let error):
@@ -171,6 +176,16 @@ final class LocalStorageManager: LocalStorageManagerable {
                 realm.delete(itemModel)
             }
             networkStorageManager.deleteItem(convertedItem(item))
+        } catch {
+            throw StorageError.deleteError
+        }
+    }
+    
+    private func deleteAll() throws {
+        do {
+            try realm.write {
+                realm.deleteAll()
+            }
         } catch {
             throw StorageError.deleteError
         }

--- a/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
+++ b/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
@@ -66,6 +66,7 @@ final class LocalStorageManager: LocalStorageManagerable {
                     selectListModel(item.type).append(item.convertedItem)
                 }
             }
+            networkStorageManager.create(item.convertedItem)
         } catch {
             throw StorageError.creatError
         }

--- a/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
+++ b/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
@@ -84,6 +84,7 @@ final class LocalStorageManager: LocalStorageManagerable {
                 itemModel?.deadline = item.deadline
                 itemModel?.body = item.body
             }
+            networkStorageManager.updateItem(item.convertedItem)
         } catch {
             throw StorageError.updateError
         }

--- a/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
+++ b/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
@@ -13,6 +13,7 @@ protocol LocalStorageManagerable {
     func createItem(_ item: ListItem) throws
     func updateItem(_ item: ListItem) throws
     func deleteItem(_ item: ListItem) throws
+    func addHistory(title: String) throws
 }
 
 final class LocalStorageManager: LocalStorageManagerable {
@@ -84,7 +85,7 @@ final class LocalStorageManager: LocalStorageManagerable {
         return list
     }
     
-    func createItem(_ item: ListItem) throws{
+    func createItem(_ item: ListItem) throws {
         guard let realm = realm else {
             return
         }
@@ -113,6 +114,29 @@ final class LocalStorageManager: LocalStorageManagerable {
             networkStorageManager.create(convertedItem(item))
         } catch {
             throw StorageError.creatError
+        }
+    }
+    
+    func addHistory(title: String) throws {
+        guard let realm = realm else {
+            return
+        }
+        
+        do {
+            try realm.write {
+                guard let listModel = realm.objects(LocalStorage.self).first else {
+                    return
+                }
+                
+                let history = History()
+                history.title = title
+                
+                listModel.history.append(history)
+                
+                print(listModel.history)
+            }
+        } catch{
+            throw StorageError.historyError
         }
     }
     

--- a/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
+++ b/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
@@ -102,6 +102,7 @@ final class LocalStorageManager: LocalStorageManagerable {
             try realm?.write {
                 realm?.delete(itemModel)
             }
+            networkStorageManager.deleteItem(item.convertedItem)
         } catch {
             throw StorageError.deleteError
         }

--- a/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
+++ b/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
@@ -73,7 +73,15 @@ final class LocalStorageManager: LocalStorageManagerable {
         do {
             if realm.objects(LocalStorage.self).isEmpty {
                 let listModel = LocalStorage()
-                listModel.todoList.append(convertedItem(item))
+                switch item.type {
+                case .todo:
+                    listModel.todoList.append(convertedItem(item))
+                case .doing:
+                    listModel.doingList.append(convertedItem(item))
+                case .done:
+                    listModel.doneList.append(convertedItem(item))
+                }
+                
                 
                 try realm.write {
                     realm.add(listModel)

--- a/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
+++ b/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
@@ -9,9 +9,9 @@ import RealmSwift
 
 protocol LocalStorageManagerable {
     func readList(_ type: ListType) -> [ListItem]
-    func createItem(_ item: ListItem) throws -> [ListItem]
-    func updateItem(_ item: ListItem) throws -> [ListItem]
-    func deleteItem(_ item: ListItem) throws -> [ListItem]
+    func createItem(_ item: ListItem) throws
+    func updateItem(_ item: ListItem) throws
+    func deleteItem(_ item: ListItem) throws
 }
 
 final class LocalStorageManager: LocalStorageManagerable {
@@ -23,14 +23,14 @@ final class LocalStorageManager: LocalStorageManagerable {
     }
     
     private func convertedItem(_ item: ListItem) -> ListItemDTO {
-            let itemModel = ListItemDTO()
-            itemModel.title = item.title
-            itemModel.body = item.body
-            itemModel.deadline = item.deadline
-            itemModel.type = item.type.rawValue
-            itemModel.id = item.id
-            
-            return itemModel
+        let itemModel = ListItemDTO()
+        itemModel.title = item.title
+        itemModel.body = item.body
+        itemModel.deadline = item.deadline
+        itemModel.type = item.type.rawValue
+        itemModel.id = item.id
+        
+        return itemModel
     }
     
     private func selectListModel(_ type: ListType) -> List<ListItemDTO> {
@@ -65,9 +65,9 @@ final class LocalStorageManager: LocalStorageManagerable {
         return list
     }
     
-    func createItem(_ item: ListItem) throws -> [ListItem] {
+    func createItem(_ item: ListItem) throws{
         guard let realm = realm else {
-            return []
+            return
         }
         
         do {
@@ -87,11 +87,9 @@ final class LocalStorageManager: LocalStorageManagerable {
         } catch {
             throw StorageError.creatError
         }
-        
-        return readList(item.type)
     }
     
-    func updateItem(_ item: ListItem) throws -> [ListItem] {
+    func updateItem(_ item: ListItem) throws {
         let itemModel = selectListModel(item.type)
             .filter(NSPredicate(format: "id = %@", item.id)).first
         
@@ -105,14 +103,12 @@ final class LocalStorageManager: LocalStorageManagerable {
         } catch {
             throw StorageError.updateError
         }
-        
-        return readList(item.type)
     }
     
-    func deleteItem(_ item: ListItem) throws -> [ListItem] {
+    func deleteItem(_ item: ListItem) throws {
         guard let itemModel = selectListModel(item.type)
             .filter(NSPredicate(format: "id = %@", item.id)).first else {
-            return []
+            return
         }
         
         do {
@@ -123,7 +119,5 @@ final class LocalStorageManager: LocalStorageManagerable {
         } catch {
             throw StorageError.deleteError
         }
-        
-        return readList(item.type)
     }
 }

--- a/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
+++ b/ProjectManager/ProjectManager/Storage/LocalStorageManager.swift
@@ -43,7 +43,13 @@ final class LocalStorageManager: LocalStorageManagerable {
     
     func readList(_ type: ListType) -> [ListItem] {
         let list: [ListItem] = selectListModel(type)
-            .compactMap { $0.convertedItem }
+            .compactMap {
+                ListItem(title: $0.title,
+                         body: $0.body,
+                         deadline: $0.deadline,
+                         type: ListType(rawValue: $0.type) ?? .todo,
+                         id: $0.id)
+            }
             .sorted { $0.deadline < $1.deadline }
         return list
     }

--- a/ProjectManager/ProjectManager/Storage/NetworkStorage.swift
+++ b/ProjectManager/ProjectManager/Storage/NetworkStorage.swift
@@ -29,7 +29,7 @@ struct NetworkStorageManager: NetworkStorageManagerable {
             "type": item.type,
             "id": item.id
         ]
-        database.reference().child(item.type).child(item.id).setValue(object)
+        database.reference().child(item.id).setValue(object)
     }
     
     func read() {

--- a/ProjectManager/ProjectManager/Storage/NetworkStorage.swift
+++ b/ProjectManager/ProjectManager/Storage/NetworkStorage.swift
@@ -8,7 +8,7 @@
 import FirebaseDatabase
 
 protocol NetworkStorageManagerable {
-    func create()
+    func create(_ item: ListItemDTO)
     func read()
     func update()
     func delete()
@@ -21,8 +21,15 @@ struct NetworkStorageManager: NetworkStorageManagerable {
         database.isPersistenceEnabled = true
     }
     
-    func create() {
-        
+    func create(_ item: ListItemDTO) {
+        let object: [String: Any] = [
+            "title": item.title,
+            "body": item.body,
+            "deadline": item.deadline.timeIntervalSince1970,
+            "type": item.type,
+            "id": item.id
+        ]
+        database.reference().child(item.type).child(item.id).setValue(object)
     }
     
     func read() {

--- a/ProjectManager/ProjectManager/Storage/NetworkStorage.swift
+++ b/ProjectManager/ProjectManager/Storage/NetworkStorage.swift
@@ -43,10 +43,10 @@ struct NetworkStorageManager: NetworkStorageManagerable {
             "type": item.type,
             "id": item.id
         ]
-        database.reference().child(item.type).child(item.id).updateChildValues(object)
+        database.reference().child(item.id).updateChildValues(object)
     }
     
     func deleteItem(_ item: ListItemDTO) {
-        database.reference().child(item.type).child(item.id).removeValue()
+        database.reference().child(item.id).removeValue()
     }
 }

--- a/ProjectManager/ProjectManager/Storage/NetworkStorage.swift
+++ b/ProjectManager/ProjectManager/Storage/NetworkStorage.swift
@@ -7,7 +7,7 @@
 
 import FirebaseDatabase
 
-struct NetworkStorage {
+struct NetworkStorageManager {
     private let database = Database.database()
     
     init() {

--- a/ProjectManager/ProjectManager/Storage/NetworkStorage.swift
+++ b/ProjectManager/ProjectManager/Storage/NetworkStorage.swift
@@ -1,0 +1,16 @@
+//
+//  NetworkStorage.swift
+//  ProjectManager
+//
+//  Created by 두기 on 2022/07/25.
+//
+
+import FirebaseDatabase
+
+struct NetworkStorage {
+    private let database = Database.database()
+    
+    init() {
+        database.isPersistenceEnabled = true
+    }
+}

--- a/ProjectManager/ProjectManager/Storage/NetworkStorage.swift
+++ b/ProjectManager/ProjectManager/Storage/NetworkStorage.swift
@@ -11,7 +11,7 @@ protocol NetworkStorageManagerable {
     func create(_ item: ListItemDTO)
     func read()
     func updateItem(_ item: ListItemDTO)
-    func delete()
+    func deleteItem(_ item: ListItemDTO)
 }
 
 struct NetworkStorageManager: NetworkStorageManagerable {
@@ -46,7 +46,7 @@ struct NetworkStorageManager: NetworkStorageManagerable {
         database.reference().child(item.type).child(item.id).updateChildValues(object)
     }
     
-    func delete() {
-        
+    func deleteItem(_ item: ListItemDTO) {
+        database.reference().child(item.type).child(item.id).removeValue()
     }
 }

--- a/ProjectManager/ProjectManager/Storage/NetworkStorage.swift
+++ b/ProjectManager/ProjectManager/Storage/NetworkStorage.swift
@@ -1,5 +1,5 @@
 //
-//  NetworkStorage.swift
+//  NetworkStorageManager.swift
 //  ProjectManager
 //
 //  Created by 두기 on 2022/07/25.
@@ -7,10 +7,32 @@
 
 import FirebaseDatabase
 
-struct NetworkStorageManager {
+protocol NetworkStorageManagerable {
+    func create()
+    func read()
+    func update()
+    func delete()
+}
+
+struct NetworkStorageManager: NetworkStorageManagerable {
     private let database = Database.database()
     
     init() {
         database.isPersistenceEnabled = true
+    }
+    
+    func create() {
+        
+    }
+    
+    func read() {
+    }
+    
+    func update() {
+    
+    }
+    
+    func delete() {
+        
     }
 }

--- a/ProjectManager/ProjectManager/Storage/NetworkStorage.swift
+++ b/ProjectManager/ProjectManager/Storage/NetworkStorage.swift
@@ -10,7 +10,7 @@ import FirebaseDatabase
 protocol NetworkStorageManagerable {
     func create(_ item: ListItemDTO)
     func read()
-    func update()
+    func updateItem(_ item: ListItemDTO)
     func delete()
 }
 
@@ -34,9 +34,16 @@ struct NetworkStorageManager: NetworkStorageManagerable {
     
     func read() {
     }
-    
-    func update() {
-    
+
+    func updateItem(_ item: ListItemDTO) {
+        let object: [String: Any] = [
+            "title": item.title,
+            "body": item.body,
+            "deadline": item.deadline.timeIntervalSince1970,
+            "type": item.type,
+            "id": item.id
+        ]
+        database.reference().child(item.type).child(item.id).updateChildValues(object)
     }
     
     func delete() {

--- a/ProjectManager/ProjectManager/Storage/StorageError.swift
+++ b/ProjectManager/ProjectManager/Storage/StorageError.swift
@@ -10,6 +10,7 @@ enum StorageError: Error {
     case updateError
     case deleteError
     case readError
+    case networkError
     
     var errorDescription: String {
         switch self {
@@ -21,6 +22,8 @@ enum StorageError: Error {
             return "리스트 삭제에 실패하였습니다. 잠시 후 다시 시도해 주세요"
         case .readError:
             return "리스트 불러오기에 실패하였습니다. 잠시 후 다시 시도해 주세요"
+        case .networkError:
+            return "인터넷 연결이 원활하지 않습니다. 잠시 후 다시 시도해 주세요"
         }
     }
 }

--- a/ProjectManager/ProjectManager/Storage/StorageError.swift
+++ b/ProjectManager/ProjectManager/Storage/StorageError.swift
@@ -15,13 +15,13 @@ enum StorageError: Error {
     var errorDescription: String {
         switch self {
         case .creatError:
-            return "리스트 생성에 실패하였습니다. 잠시 후 다시 시도해 주세요"
+            return "리스트 생성에 실패하였습니다.\n잠시 후 다시 시도해 주세요"
         case .updateError:
-            return "리스트 수정에 실패하였습니다. 잠시 후 다시 시도해 주세요"
+            return "리스트 수정에 실패하였습니다.\n잠시 후 다시 시도해 주세요"
         case .deleteError:
-            return "리스트 삭제에 실패하였습니다. 잠시 후 다시 시도해 주세요"
+            return "리스트 삭제에 실패하였습니다.\n잠시 후 다시 시도해 주세요"
         case .readError:
-            return "리스트 불러오기에 실패하였습니다. 잠시 후 다시 시도해 주세요"
+            return "리스트 불러오기에 실패하였습니다.\n잠시 후 다시 시도해 주세요"
         case .historyError:
             return "히스토리 생성에 실패하였습니다."
         }

--- a/ProjectManager/ProjectManager/Storage/StorageError.swift
+++ b/ProjectManager/ProjectManager/Storage/StorageError.swift
@@ -10,6 +10,7 @@ enum StorageError: Error {
     case updateError
     case deleteError
     case readError
+    case historyError
     
     var errorDescription: String {
         switch self {
@@ -21,6 +22,8 @@ enum StorageError: Error {
             return "리스트 삭제에 실패하였습니다. 잠시 후 다시 시도해 주세요"
         case .readError:
             return "리스트 불러오기에 실패하였습니다. 잠시 후 다시 시도해 주세요"
+        case .historyError:
+            return "히스토리 생성에 실패하였습니다."
         }
     }
 }

--- a/ProjectManager/ProjectManager/Storage/StorageError.swift
+++ b/ProjectManager/ProjectManager/Storage/StorageError.swift
@@ -10,7 +10,6 @@ enum StorageError: Error {
     case updateError
     case deleteError
     case readError
-    case networkError
     
     var errorDescription: String {
         switch self {
@@ -22,8 +21,6 @@ enum StorageError: Error {
             return "리스트 삭제에 실패하였습니다. 잠시 후 다시 시도해 주세요"
         case .readError:
             return "리스트 불러오기에 실패하였습니다. 잠시 후 다시 시도해 주세요"
-        case .networkError:
-            return "인터넷 연결이 원활하지 않습니다. 잠시 후 다시 시도해 주세요"
         }
     }
 }

--- a/ProjectManager/ProjectManager/Storage/StorageError.swift
+++ b/ProjectManager/ProjectManager/Storage/StorageError.swift
@@ -9,6 +9,7 @@ enum StorageError: Error {
     case creatError
     case updateError
     case deleteError
+    case readError
     
     var errorDescription: String {
         switch self {
@@ -18,6 +19,8 @@ enum StorageError: Error {
             return "리스트 수정에 실패하였습니다. 잠시 후 다시 시도해 주세요"
         case .deleteError:
             return "리스트 삭제에 실패하였습니다. 잠시 후 다시 시도해 주세요"
+        case .readError:
+            return "리스트 불러오기에 실패하였습니다. 잠시 후 다시 시도해 주세요"
         }
     }
 }

--- a/ProjectManager/ProjectManager/Storage/StorageError.swift
+++ b/ProjectManager/ProjectManager/Storage/StorageError.swift
@@ -11,6 +11,8 @@ enum StorageError: Error {
     case deleteError
     case readError
     case historyError
+    case networkError
+    case localStorageError
     
     var errorDescription: String {
         switch self {
@@ -24,6 +26,10 @@ enum StorageError: Error {
             return "리스트 불러오기에 실패하였습니다.\n잠시 후 다시 시도해 주세요"
         case .historyError:
             return "히스토리 생성에 실패하였습니다."
+        case .networkError:
+            return "어플 최초 실행시 서버와의 연동을 위해 인터넷 연결이 필요합니다.\n연결 확인 후 어플을 다시 실행해주세요."
+        case .localStorageError:
+            return "저장소를 불러오는 데 실패했습니다.\n잠시 후 다시 시도해 주세요"
         }
     }
 }

--- a/ProjectManager/ProjectManager/Utils/DateConverter.swift
+++ b/ProjectManager/ProjectManager/Utils/DateConverter.swift
@@ -10,7 +10,7 @@ import Foundation
 struct DateConverter {
     static let dateFormatter = DateFormatter()
     
-    static func dateToString(_ date: Date) -> String {
+    static func listDateString(_ date: Date) -> String {
         dateFormatter.locale = .autoupdatingCurrent
         dateFormatter.timeZone = .autoupdatingCurrent
         dateFormatter.dateFormat = "yyyy. M. d."

--- a/ProjectManager/ProjectManager/Utils/DateConverter.swift
+++ b/ProjectManager/ProjectManager/Utils/DateConverter.swift
@@ -19,4 +19,14 @@ struct DateConverter {
         
         return stringDate
     }
+    
+    static func historyDateString(_ date: Date) -> String {
+        dateFormatter.locale = .autoupdatingCurrent
+        dateFormatter.timeZone = .autoupdatingCurrent
+        dateFormatter.dateFormat = "MMM d, y h:mm:ss a"
+        
+        let stringDate = dateFormatter.string(from: date)
+        
+        return stringDate
+    }
 }

--- a/ProjectManager/ProjectManager/Utils/Extension/UIViewController + Extension.swift
+++ b/ProjectManager/ProjectManager/Utils/Extension/UIViewController + Extension.swift
@@ -21,9 +21,9 @@ extension UIViewController {
         self.present(alert, animated: true)
     }
     
-    func showNetworkErrorAlert() {
-        let alert = UIAlertController(title: "인터넷 연결을 확인해주세요",
-                                      message: "어플 최초 실행시 서버와의 연동을 위해 인터넷 연결이 필요합니다.\n연결 확인 후 어플을 다시 실행해주세요.",
+    func showExitAlert(message: String) {
+        let alert = UIAlertController(title: "",
+                                      message: message,
                                       preferredStyle: .alert)
         let action = UIAlertAction(title: "확인", style: .default) { _ in
             exit(0)

--- a/ProjectManager/ProjectManager/Utils/Extension/UIViewController + Extension.swift
+++ b/ProjectManager/ProjectManager/Utils/Extension/UIViewController + Extension.swift
@@ -8,9 +8,9 @@
 import UIKit
 
 extension UIViewController {
-    func showErrorAlert(messege: String?) {
+    func showErrorAlert(message: String?) {
         let alert = UIAlertController(title: "오류",
-                                      message: messege ?? "예상치 못한 오류가 발생했습니다. 잠시 후 다시 시도해 주세요",
+                                      message: message ?? "예상치 못한 오류가 발생했습니다. 잠시 후 다시 시도해 주세요",
                                       preferredStyle: .alert)
         let action = UIAlertAction(title: "확인", style: .default) { _ in
             self.dismiss(animated: true)

--- a/ProjectManager/ProjectManager/Utils/Extension/UIViewController + Extension.swift
+++ b/ProjectManager/ProjectManager/Utils/Extension/UIViewController + Extension.swift
@@ -8,8 +8,10 @@
 import UIKit
 
 extension UIViewController {
-    func showErrorAlert(messege: String) {
-        let alert = UIAlertController(title: "오류", message: messege, preferredStyle: .alert)
+    func showErrorAlert(messege: String?) {
+        let alert = UIAlertController(title: "오류",
+                                      message: messege ?? "예상치 못한 오류가 발생했습니다. 잠시 후 다시 시도해 주세요",
+                                      preferredStyle: .alert)
         let action = UIAlertAction(title: "확인", style: .default) { _ in
             self.dismiss(animated: true)
         }

--- a/ProjectManager/ProjectManager/Utils/Extension/UIViewController + Extension.swift
+++ b/ProjectManager/ProjectManager/Utils/Extension/UIViewController + Extension.swift
@@ -20,4 +20,17 @@ extension UIViewController {
         
         self.present(alert, animated: true)
     }
+    
+    func showNetworkErrorAlert() {
+        let alert = UIAlertController(title: "인터넷 연결을 확인해주세요",
+                                      message: "어플 최초 실행시 서버와의 연동을 위해 인터넷 연결이 필요합니다.\n연결 확인 후 어플을 다시 실행해주세요.",
+                                      preferredStyle: .alert)
+        let action = UIAlertAction(title: "확인", style: .default) { _ in
+            exit(0)
+        }
+        
+        alert.addAction(action)
+        
+        self.present(alert, animated: true)
+    }
 }

--- a/README.md
+++ b/README.md
@@ -12,12 +12,15 @@
 |이동|삭제|
 |<img src="https://i.imgur.com/QmVBxdd.gif" width="350" height="230"/>|<img src="https://i.imgur.com/y2HHGq2.gif" width="350" height="230"/>|
 |로컬저장소|원격저장소|
-|<img src="https://user-images.githubusercontent.com/82325822/180371884-de5660f6-63b4-4d07-95d6-fe84a560929d.gif" width="350" height="230"/>|추가 예정|
+|<img src="https://i.imgur.com/FYuyfNa.gif" width="350" height="230"/>|<img src="https://i.imgur.com/ysjwk6s.gif" width="350" height="230"/>|
+
 
 ## 기능 구현
 - title, deadline, body로 구성된 Todo List 작성
 - Rx를 이용해 데이터 화면에 표시
 - Realm을 통해 로컬 저장소에 저장해 어플이 종료되도 작성된 List 유지
+- Firebase를 통해 서버에 List백업 기능 구현
+- 현재 인터넷 상태를 사용자가 알 수 있도록 UI에 표시
 
 ## 개발환경 및 라이브러리
 - [![swift](https://img.shields.io/badge/swift-5.6-orange)]()
@@ -25,13 +28,14 @@
 - [![xcode](https://img.shields.io/badge/RxSwift-6.5-hotpink)]()
 - [![xcode](https://img.shields.io/badge/SnapKit-5.6-skyblue)]()
 - [![swift](https://img.shields.io/badge/Realm-10.28.2-pink)]()
+- [![swift](https://img.shields.io/badge/Firebase-9.3.0-yellow)]()
 - [![xcode](https://img.shields.io/badge/SwiftLint-red)]()
 ***
 
 # 📌  저장소 선택
 ### 로컬 저장소
 일단 로컬 저장소는 `CoreData`와 `Realm` 둘 사이에서 고민을 하다 `Realm`으로 선택을 하게 되었는데 
-가장 큰 이유는 세 가지임
+가장 큰 이유는 아래와 같다
 1. iOS와 Android를 모두 지원해 두 플랫폼간 호환이 가능하다
 2. Realm이 속도가 더 빠르다
 3. CoreData는 사용을 해봤기에 처음 접해보는 Realm을 사용해 보고 싶음
@@ -42,12 +46,12 @@
 ### 원격 저장소
 원격 저장소는 가장 많이 알려진 `Firebase`, `iCloud`, `Dropbox` 이 세가지 중에서 고민을 했었는데
 
-로컬저장소와 마찬가지로 Android와의 호환성을 위해 `iCloud`는 제외하였고 `Dropbox`의 경우에는 자료를 찾아보기가 생각보다 힘들어서 `Firebase`를 선택하게 되었음
+로컬저장소와 마찬가지로 Android와의 호환성을 위해 `iCloud`는 제외하였고 `Dropbox`의 경우에는 자료를 찾아보기가 생각보다 힘들어서 `Firebase`를 선택하게 되었다
 
 #### Realtime Database vs  Cloud Firestore
 `Firebase`내에서도 두 가지 데이터 베이스가 존재하였는데 이번 `프로젝트 관리 앱`같은 경우는 대용량 데이터를 주고받을 일이 없기도 하고 일단 `Firebase`홈페이지에
 ![](https://i.imgur.com/wjCcxwx.png)
-이런 내용이 있기도 했고 아래 고려사항 체크도 해보니 `Realtime Database`가 더 적합한 것으로 확인되어 선택하게 되었음
+이런 내용이 있기도 했고 아래 고려사항 체크도 해보니 `Realtime Database`가 더 적합한 것으로 확인되어 선택하게 되었다
 
 
 ## Trouble Shooting
@@ -64,7 +68,7 @@ mvvm 패턴을 구현함에 있어 viewcontroller도 뷰의 역할을 하도록 
 아직은 로컬 및 원격 저장소를 구현하기 전이기에 Storageable이라는 프로토콜을 만들어 해당 프로토콜을 준수하는 객체가 저장소가 될 수 있도록(실제 저장소가 생기면 바꿔치기만 할 수 있도록) 구현
 
 ### 📌 3. 저장소 공유
-MainViewController에서는 read, delete를 DetailViewController에서는 create, update를 하기에 저장소는 공유가 되어야 하는데 세가지 방법 중 고민함
+MainViewController에서는 read, delete를 DetailViewController에서는 create, update를 하기에 저장소는 공유가 되어야 하는데 세가지 방법 중 고민
 
 1. detailview를 present할 때 MainViewModel을 주입시킨다
 2. storage를 싱글톤으로 구현한다
@@ -90,7 +94,6 @@ view의 이벤트에 따라 적절한 output을 연결시키는 것이 중요!
 
 그래서 각각의 타입마다 배열을 만들어주었으며 이 때 생기는 중복코드를 제거하기 위해 각 타입에 맞는 배열을 반환해주는 메서드 생성
 
-
 #### 로컬 저장소
 ![](https://i.imgur.com/atloxdb.png)
 
@@ -102,11 +105,32 @@ view의 이벤트에 따라 적절한 output을 연결시키는 것이 중요!
 
 ![](https://i.imgur.com/FTySTO7.png)
 
+### 📌 6. 원격 저장소 저장 시점
+상시 서버와 소통하면서 지속적으로 연동 vs 특정 시점에만 서버에 요청
+
+전자의 방식으로 구현하게된다면 굳이 로컬 저장소를 쓸 필요가 없을 뿐더러 서버에 지속적으로 데이터를 주고 받아야 한다고 생각해 후자의 방식으로 구현
+
+### 작동 시점
+
+### 1. 어플 최초 실행시
+![](https://i.imgur.com/SWrNDBg.png)
+UserDefaults의 `lunchedBefore`키를 이용해 최초 실행인지 아닌지를 판단해 서버로부터 데이터를 받아 올 수 있도록 했다
+
+### 2. ListItem 수정시
+ListItem의 creat, update, delete 의 모든 수정사항이 생길 경우 원격저장소에 연동할 수 있도록 구현했다
+
+#### 오프라인 저장소
+![](https://i.imgur.com/CHLTUb2.png)
+
+firebase홈페이지를 찾아보니 오프라인 저장기능이 있는 것을 확인
+작동원리를 보니 인터넷 연결이 되어있지 않을 때 서버에 무언가를 요청할 경우 캐시에 요청 사항을 저장해뒀다가 인터넷에 연결되었을 때 변경사항을 반영한다는 내용이었으며 이에 따라 오프라인 저장 기능 구현
 
 ## 배운 개념
 - RxSwift
 - MVVM
 - Realm
+- Firebase
+- NWPathMonitor
 
 ## 커밋 룰
 Commit message

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@
 |이동|삭제|
 |<img src="https://i.imgur.com/QmVBxdd.gif" width="350" height="230"/>|<img src="https://i.imgur.com/y2HHGq2.gif" width="350" height="230"/>|
 |로컬저장소|원격저장소|
-|<img src="https://i.imgur.com/FYuyfNa.gif" width="350" height="230"/>|<img src="https://i.imgur.com/ysjwk6s.gif" width="350" height="230"/>|
-
+|<img src="https://user-images.githubusercontent.com/82325822/185056431-9e5d6652-6c44-4817-80c0-f110380d82c8.gif" width="350" height="230"/>|<img src="https://user-images.githubusercontent.com/82325822/185056561-05523b43-1e9c-4f6b-8e50-225364a19197.gif" width="350" height="230"/>|
 
 ## 기능 구현
 - title, deadline, body로 구성된 Todo List 작성


### PR DESCRIPTION
@TTOzzi 
안녕하세요 또치!

이번이 마지막 PR이 될 것 같네요!
프로젝트를 진행하다보니 3-3 STEP으로 예정되어있었던 history와 인터넷 연결 상태 ui표시 기능 까지 이번 스텝에 포함에 pr 보내게 되었습니다
(인터넷 연결 상태 ui를 표시하기 위해 하단에 stackview를 추가하면서 undo, redo버튼도 기능 없이 추가는 해둔 상태입니다!)
마지막 리뷰도 잘 부탁드립니다

## 원격 저장소의 작동 시점

### 1. 어플 최초 실행시
![](https://i.imgur.com/SWrNDBg.png)
UserDefaults의 `lunchedBefore`키를 이용해 최초 실행인지 아닌지를 판단해 서버로부터 데이터를 받아 올 수 있도록 하였습니다

### 2. ListItem 수정시
ListItem의 creat, update, delete 의 모든 수정사항이 생길 경우 원격저장소에 연동할 수 있도록 구현하였습니다

#### 오프라인 저장소
![](https://i.imgur.com/CHLTUb2.png)

firebase홈페이지를 찾아보니 오프라인 저장기능이 있는 것을 확인 했습니다
작동원리를 보니 인터넷 연결이 되어있지 않을 때 서버에 무언가를 요청할 경우 캐시에 요청 사항을 저장해뒀다가 인터넷에 연결되었을 때 변경사항을 반영한다는 내용이었습니다



## 궁금한점

### 1.image가 아닌 text로 버튼 선언시 animation 활성화 하는 법
![](https://i.imgur.com/5JOIQa4.gif)

스토리보드로 선언할 때는 text로 선언해도 animation이 잘 작동됐는데 코드로 선언하니 이게 반응이 없더라구요
그래서 어떻게 활성화 해야하는지 궁금합니다

### 2. 너무 짧은 텀으로 프로젝트를 빌드하면 변경 사항 반영이 안되는지
![](https://i.imgur.com/x6YZja4.png)
위 사진의 bool값은 최초 실행 감지인 UserDefaults의 `lunchedBefore`키의 bool값입니다

init시점에 한번 print를 하고 서버로부터 list들을 받아오는 것이 성공하게 되면 그 이후에 값을 true로 변경하여 다시 받아오지 않도록 로직을 구현하였습니다
그런데 어떤 특정 시점에서는(그 시점을 정확히 찾지는 못했으나 앱을 짧은 텀으로 빌드한 경우에는 99% 발생함) 위와갔이 true 바뀌었으나 다시 빌드를 하면

![](https://i.imgur.com/UQJeyS3.png)
이렇게 false로 나왔습니다
그래서 다시 서버로부터 list들을 요청하게 되면서 realm에 primary key가 중복된 객체가 생성되면서 크래쉬가 발생했습니다

일단은 위 크래쉬를 방지하기 위해 서버로부터 data를 받아오게 되면 realm에 저장된 정보들은 전체 삭제 한 뒤에 받아올 수 있도록 구현해 놓은 상태입니다

### 3. 어플을 종료시키는 alert을 두개로 분리할지..?
![](https://i.imgur.com/CpR9Yxc.png)
이렇게 action을 매개변수로 받아서 alert을 사용할 때마다 코드를 작성할지 아니면 지금 처럼 종료하는 alert 그 외 alert을 따로 구현하는게 나을지 여쭤보고 싶습니다
(일단 지금은 action을 매개변수로 받으면 중복코드가 너무 많이 발생한다고 생각해 두개로 나눠놓은 상황입니다)

### 4. 시뮬레이터에서의 네트워크 상태 체크
![](https://i.imgur.com/rCA5tdj.png)
위와 같이 네트워크 상태를 체크하는 로직을 구현했는데 이게 바로바로 반영이 안되는 것 같아서 코드를 잘못짠건가...? 하는 생각에 다른 프로젝트를 추가해 제 폰으로 빌드를 해봤는데 인터넷 끄고 켤때마다 즉각적으로 반영이 되더라구요 원래 시뮬레이터는 잘 반영이 안되나요??