### PR TITLE
프로젝트 매니저 [STEP2.5] 리지

### DIFF
--- a/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
+++ b/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
@@ -12,8 +12,11 @@
 		C7431F0A25F51E1D0094C4CF /* PlanManagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7431F0925F51E1D0094C4CF /* PlanManagerViewController.swift */; };
 		C7431F0F25F51E1E0094C4CF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C7431F0E25F51E1E0094C4CF /* Assets.xcassets */; };
 		C7431F1225F51E1E0094C4CF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C7431F1025F51E1E0094C4CF /* LaunchScreen.storyboard */; };
+		FB7522B62A2869E800C051E9 /* MockPlanSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7522B52A2869E800C051E9 /* MockPlanSubscriber.swift */; };
+		FBB1445E2A27598800F4D4A2 /* PlanViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB1445D2A27598800F4D4A2 /* PlanViewModelTests.swift */; };
 		FBC20AA32A1F90AB00EDB6A8 /* PlanManagerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBC20AA22A1F90AB00EDB6A8 /* PlanManagerViewModel.swift */; };
 		FBC20AAB2A25B14900EDB6A8 /* PlanSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBC20AAA2A25B14900EDB6A8 /* PlanSubscriber.swift */; };
+		FBC20AB32A270F9100EDB6A8 /* PlanManagerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBC20AB22A270F9100EDB6A8 /* PlanManagerViewModelTests.swift */; };
 		FBF0627D2A14639D0088A9E3 /* PlusTodoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBF0627C2A14639D0088A9E3 /* PlusTodoViewController.swift */; };
 		FBF062882A14B8A00088A9E3 /* PlanTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBF062872A14B8A00088A9E3 /* PlanTableViewCell.swift */; };
 		FBF0628A2A14B9720088A9E3 /* PlanViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBF062892A14B9720088A9E3 /* PlanViewModel.swift */; };
@@ -29,6 +32,23 @@
 		FBF062B02A1F16010088A9E3 /* PlanViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBF062AF2A1F16010088A9E3 /* PlanViewController.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		FBB144582A2758A400F4D4A2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C7431EFA25F51E1D0094C4CF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C7431F0125F51E1D0094C4CF;
+			remoteInfo = ProjectManager;
+		};
+		FBC20AB42A270F9100EDB6A8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C7431EFA25F51E1D0094C4CF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C7431F0125F51E1D0094C4CF;
+			remoteInfo = ProjectManager;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		C7431F0225F51E1D0094C4CF /* ProjectManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ProjectManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7431F0525F51E1D0094C4CF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -37,8 +57,14 @@
 		C7431F0E25F51E1E0094C4CF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C7431F1125F51E1E0094C4CF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C7431F1325F51E1E0094C4CF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FB7522B52A2869E800C051E9 /* MockPlanSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPlanSubscriber.swift; sourceTree = "<group>"; };
+		FBB144542A2758A400F4D4A2 /* PlanViewModelTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PlanViewModelTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FBB1445D2A27598800F4D4A2 /* PlanViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanViewModelTests.swift; sourceTree = "<group>"; };
 		FBC20AA22A1F90AB00EDB6A8 /* PlanManagerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanManagerViewModel.swift; sourceTree = "<group>"; };
 		FBC20AAA2A25B14900EDB6A8 /* PlanSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanSubscriber.swift; sourceTree = "<group>"; };
+		FBC20AB02A270F9100EDB6A8 /* PlanManagerViewModelTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PlanManagerViewModelTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FBC20AB22A270F9100EDB6A8 /* PlanManagerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanManagerViewModelTests.swift; sourceTree = "<group>"; };
+		FBC20AB92A270FB800EDB6A8 /* ProjectManager.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = ProjectManager.xctestplan; sourceTree = "<group>"; };
 		FBF0627B2A132F820088A9E3 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		FBF0627C2A14639D0088A9E3 /* PlusTodoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusTodoViewController.swift; sourceTree = "<group>"; };
 		FBF062872A14B8A00088A9E3 /* PlanTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlanTableViewCell.swift; path = ProjectManager/View/PlanTableViewCell.swift; sourceTree = SOURCE_ROOT; };
@@ -63,14 +89,30 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FBB144512A2758A400F4D4A2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FBC20AAD2A270F9100EDB6A8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		C7431EF925F51E1D0094C4CF = {
 			isa = PBXGroup;
 			children = (
+				FBC20AB92A270FB800EDB6A8 /* ProjectManager.xctestplan */,
 				FBF0627B2A132F820088A9E3 /* .swiftlint.yml */,
 				C7431F0425F51E1D0094C4CF /* ProjectManager */,
+				FBC20AB12A270F9100EDB6A8 /* ProjectManagerTests */,
 				C7431F0325F51E1D0094C4CF /* Products */,
 			);
 			sourceTree = "<group>";
@@ -79,6 +121,8 @@
 			isa = PBXGroup;
 			children = (
 				C7431F0225F51E1D0094C4CF /* ProjectManager.app */,
+				FBC20AB02A270F9100EDB6A8 /* PlanManagerViewModelTests.xctest */,
+				FBB144542A2758A400F4D4A2 /* PlanViewModelTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -90,6 +134,7 @@
 				FBF062832A14ACA20088A9E3 /* ViewModel */,
 				FBF062812A1488E00088A9E3 /* View */,
 				FBF062982A166B4D0088A9E3 /* ViewController */,
+				FB7522B42A2869C200C051E9 /* Mock */,
 				C7431F0525F51E1D0094C4CF /* AppDelegate.swift */,
 				C7431F0725F51E1D0094C4CF /* SceneDelegate.swift */,
 				C7431F1325F51E1E0094C4CF /* Info.plist */,
@@ -97,6 +142,23 @@
 				C7431F1025F51E1E0094C4CF /* LaunchScreen.storyboard */,
 			);
 			path = ProjectManager;
+			sourceTree = "<group>";
+		};
+		FB7522B42A2869C200C051E9 /* Mock */ = {
+			isa = PBXGroup;
+			children = (
+				FB7522B52A2869E800C051E9 /* MockPlanSubscriber.swift */,
+			);
+			path = Mock;
+			sourceTree = "<group>";
+		};
+		FBC20AB12A270F9100EDB6A8 /* ProjectManagerTests */ = {
+			isa = PBXGroup;
+			children = (
+				FBB1445D2A27598800F4D4A2 /* PlanViewModelTests.swift */,
+				FBC20AB22A270F9100EDB6A8 /* PlanManagerViewModelTests.swift */,
+			);
+			path = ProjectManagerTests;
 			sourceTree = "<group>";
 		};
 		FBF062812A1488E00088A9E3 /* View */ = {
@@ -164,6 +226,42 @@
 			productReference = C7431F0225F51E1D0094C4CF /* ProjectManager.app */;
 			productType = "com.apple.product-type.application";
 		};
+		FBB144532A2758A400F4D4A2 /* PlanViewModelTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FBB1445C2A2758A400F4D4A2 /* Build configuration list for PBXNativeTarget "PlanViewModelTests" */;
+			buildPhases = (
+				FBB144502A2758A400F4D4A2 /* Sources */,
+				FBB144512A2758A400F4D4A2 /* Frameworks */,
+				FBB144522A2758A400F4D4A2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FBB144592A2758A400F4D4A2 /* PBXTargetDependency */,
+			);
+			name = PlanViewModelTests;
+			productName = PlanViewModelTests;
+			productReference = FBB144542A2758A400F4D4A2 /* PlanViewModelTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		FBC20AAF2A270F9100EDB6A8 /* PlanManagerViewModelTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FBC20AB82A270F9100EDB6A8 /* Build configuration list for PBXNativeTarget "PlanManagerViewModelTests" */;
+			buildPhases = (
+				FBC20AAC2A270F9100EDB6A8 /* Sources */,
+				FBC20AAD2A270F9100EDB6A8 /* Frameworks */,
+				FBC20AAE2A270F9100EDB6A8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FBC20AB52A270F9100EDB6A8 /* PBXTargetDependency */,
+			);
+			name = PlanManagerViewModelTests;
+			productName = PlanManagerViewModelTests;
+			productReference = FBC20AB02A270F9100EDB6A8 /* PlanManagerViewModelTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -171,11 +269,19 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastSwiftUpdateCheck = 1240;
+				LastSwiftUpdateCheck = 1430;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					C7431F0125F51E1D0094C4CF = {
 						CreatedOnToolsVersion = 12.4;
+					};
+					FBB144532A2758A400F4D4A2 = {
+						CreatedOnToolsVersion = 14.3;
+						TestTargetID = C7431F0125F51E1D0094C4CF;
+					};
+					FBC20AAF2A270F9100EDB6A8 = {
+						CreatedOnToolsVersion = 14.3;
+						TestTargetID = C7431F0125F51E1D0094C4CF;
 					};
 				};
 			};
@@ -193,6 +299,8 @@
 			projectRoot = "";
 			targets = (
 				C7431F0125F51E1D0094C4CF /* ProjectManager */,
+				FBC20AAF2A270F9100EDB6A8 /* PlanManagerViewModelTests */,
+				FBB144532A2758A400F4D4A2 /* PlanViewModelTests */,
 			);
 		};
 /* End PBXProject section */
@@ -204,6 +312,20 @@
 			files = (
 				C7431F1225F51E1E0094C4CF /* LaunchScreen.storyboard in Resources */,
 				C7431F0F25F51E1E0094C4CF /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FBB144522A2758A400F4D4A2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FBC20AAE2A270F9100EDB6A8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -240,6 +362,7 @@
 				FBF062882A14B8A00088A9E3 /* PlanTableViewCell.swift in Sources */,
 				FBF0628D2A14BA780088A9E3 /* Plan.swift in Sources */,
 				FBF0627D2A14639D0088A9E3 /* PlusTodoViewController.swift in Sources */,
+				FB7522B62A2869E800C051E9 /* MockPlanSubscriber.swift in Sources */,
 				FBF062A82A1C5E230088A9E3 /* HeaderView.swift in Sources */,
 				FBC20AAB2A25B14900EDB6A8 /* PlanSubscriber.swift in Sources */,
 				FBC20AA32A1F90AB00EDB6A8 /* PlanManagerViewModel.swift in Sources */,
@@ -256,7 +379,36 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FBB144502A2758A400F4D4A2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FBC20AAC2A270F9100EDB6A8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FBC20AB32A270F9100EDB6A8 /* PlanManagerViewModelTests.swift in Sources */,
+				FBB1445E2A27598800F4D4A2 /* PlanViewModelTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		FBB144592A2758A400F4D4A2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C7431F0125F51E1D0094C4CF /* ProjectManager */;
+			targetProxy = FBB144582A2758A400F4D4A2 /* PBXContainerItemProxy */;
+		};
+		FBC20AB52A270F9100EDB6A8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C7431F0125F51E1D0094C4CF /* ProjectManager */;
+			targetProxy = FBC20AB42A270F9100EDB6A8 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		C7431F1025F51E1E0094C4CF /* LaunchScreen.storyboard */ = {
@@ -424,6 +576,94 @@
 			};
 			name = Release;
 		};
+		FBB1445A2A2758A400F4D4A2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MACOSX_DEPLOYMENT_TARGET = 13.1;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.riji.PlanViewModelTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ProjectManager.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ProjectManager";
+			};
+			name = Debug;
+		};
+		FBB1445B2A2758A400F4D4A2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MACOSX_DEPLOYMENT_TARGET = 13.1;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.riji.PlanViewModelTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ProjectManager.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ProjectManager";
+			};
+			name = Release;
+		};
+		FBC20AB62A270F9100EDB6A8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MACOSX_DEPLOYMENT_TARGET = 13.1;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.riji.PlanManagerViewModelTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ProjectManager.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ProjectManager";
+			};
+			name = Debug;
+		};
+		FBC20AB72A270F9100EDB6A8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MACOSX_DEPLOYMENT_TARGET = 13.1;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.riji.PlanManagerViewModelTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ProjectManager.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ProjectManager";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -441,6 +681,24 @@
 			buildConfigurations = (
 				C7431F1725F51E1E0094C4CF /* Debug */,
 				C7431F1825F51E1E0094C4CF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FBB1445C2A2758A400F4D4A2 /* Build configuration list for PBXNativeTarget "PlanViewModelTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FBB1445A2A2758A400F4D4A2 /* Debug */,
+				FBB1445B2A2758A400F4D4A2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FBC20AB82A270F9100EDB6A8 /* Build configuration list for PBXNativeTarget "PlanManagerViewModelTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FBC20AB62A270F9100EDB6A8 /* Debug */,
+				FBC20AB72A270F9100EDB6A8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
+++ b/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		C7431F0A25F51E1D0094C4CF /* PlanManagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7431F0925F51E1D0094C4CF /* PlanManagerViewController.swift */; };
 		C7431F0F25F51E1E0094C4CF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C7431F0E25F51E1E0094C4CF /* Assets.xcassets */; };
 		C7431F1225F51E1E0094C4CF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C7431F1025F51E1E0094C4CF /* LaunchScreen.storyboard */; };
+		FB2C68D22A28817300B9DE55 /* PlanTableCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C68D12A28817300B9DE55 /* PlanTableCellViewModelTests.swift */; };
+		FB2C68D42A28865E00B9DE55 /* TextColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2C68D32A28865E00B9DE55 /* TextColor.swift */; };
 		FB7522B62A2869E800C051E9 /* MockPlanSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7522B52A2869E800C051E9 /* MockPlanSubscriber.swift */; };
 		FB7522B82A287CC200C051E9 /* PlusTodoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7522B72A287CC200C051E9 /* PlusTodoViewModelTests.swift */; };
 		FBB1445E2A27598800F4D4A2 /* PlanViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB1445D2A27598800F4D4A2 /* PlanViewModelTests.swift */; };
@@ -58,6 +60,8 @@
 		C7431F0E25F51E1E0094C4CF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C7431F1125F51E1E0094C4CF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C7431F1325F51E1E0094C4CF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FB2C68D12A28817300B9DE55 /* PlanTableCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanTableCellViewModelTests.swift; sourceTree = "<group>"; };
+		FB2C68D32A28865E00B9DE55 /* TextColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextColor.swift; sourceTree = "<group>"; };
 		FB7522B52A2869E800C051E9 /* MockPlanSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPlanSubscriber.swift; sourceTree = "<group>"; };
 		FB7522B72A287CC200C051E9 /* PlusTodoViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusTodoViewModelTests.swift; sourceTree = "<group>"; };
 		FBB144542A2758A400F4D4A2 /* PlanViewModelTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PlanViewModelTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -157,6 +161,7 @@
 		FBC20AB12A270F9100EDB6A8 /* ProjectManagerTests */ = {
 			isa = PBXGroup;
 			children = (
+				FB2C68D12A28817300B9DE55 /* PlanTableCellViewModelTests.swift */,
 				FB7522B72A287CC200C051E9 /* PlusTodoViewModelTests.swift */,
 				FBB1445D2A27598800F4D4A2 /* PlanViewModelTests.swift */,
 				FBC20AB22A270F9100EDB6A8 /* PlanManagerViewModelTests.swift */,
@@ -167,6 +172,7 @@
 		FBF062812A1488E00088A9E3 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				FB2C68D32A28865E00B9DE55 /* TextColor.swift */,
 				FBF062872A14B8A00088A9E3 /* PlanTableViewCell.swift */,
 				FBF0628E2A1607570088A9E3 /* CircleLabel.swift */,
 				FBF062A72A1C5E230088A9E3 /* HeaderView.swift */,
@@ -373,6 +379,7 @@
 				FBF0629A2A16F6930088A9E3 /* DateFormatManager.swift in Sources */,
 				FBF062AA2A1D11B90088A9E3 /* State.swift in Sources */,
 				FBF062972A166AD90088A9E3 /* SavingItemDelegate.swift in Sources */,
+				FB2C68D42A28865E00B9DE55 /* TextColor.swift in Sources */,
 				C7431F0625F51E1D0094C4CF /* AppDelegate.swift in Sources */,
 				FBF062A02A1B391B0088A9E3 /* PlusTodoViewModel.swift in Sources */,
 				FBF062B02A1F16010088A9E3 /* PlanViewController.swift in Sources */,
@@ -395,6 +402,7 @@
 			files = (
 				FBC20AB32A270F9100EDB6A8 /* PlanManagerViewModelTests.swift in Sources */,
 				FBB1445E2A27598800F4D4A2 /* PlanViewModelTests.swift in Sources */,
+				FB2C68D22A28817300B9DE55 /* PlanTableCellViewModelTests.swift in Sources */,
 				FB7522B82A287CC200C051E9 /* PlusTodoViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
+++ b/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		C7431F0F25F51E1E0094C4CF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C7431F0E25F51E1E0094C4CF /* Assets.xcassets */; };
 		C7431F1225F51E1E0094C4CF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C7431F1025F51E1E0094C4CF /* LaunchScreen.storyboard */; };
 		FB7522B62A2869E800C051E9 /* MockPlanSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7522B52A2869E800C051E9 /* MockPlanSubscriber.swift */; };
+		FB7522B82A287CC200C051E9 /* PlusTodoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7522B72A287CC200C051E9 /* PlusTodoViewModelTests.swift */; };
 		FBB1445E2A27598800F4D4A2 /* PlanViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB1445D2A27598800F4D4A2 /* PlanViewModelTests.swift */; };
 		FBC20AA32A1F90AB00EDB6A8 /* PlanManagerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBC20AA22A1F90AB00EDB6A8 /* PlanManagerViewModel.swift */; };
 		FBC20AAB2A25B14900EDB6A8 /* PlanSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBC20AAA2A25B14900EDB6A8 /* PlanSubscriber.swift */; };
@@ -58,6 +59,7 @@
 		C7431F1125F51E1E0094C4CF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C7431F1325F51E1E0094C4CF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FB7522B52A2869E800C051E9 /* MockPlanSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPlanSubscriber.swift; sourceTree = "<group>"; };
+		FB7522B72A287CC200C051E9 /* PlusTodoViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusTodoViewModelTests.swift; sourceTree = "<group>"; };
 		FBB144542A2758A400F4D4A2 /* PlanViewModelTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PlanViewModelTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FBB1445D2A27598800F4D4A2 /* PlanViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanViewModelTests.swift; sourceTree = "<group>"; };
 		FBC20AA22A1F90AB00EDB6A8 /* PlanManagerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanManagerViewModel.swift; sourceTree = "<group>"; };
@@ -155,6 +157,7 @@
 		FBC20AB12A270F9100EDB6A8 /* ProjectManagerTests */ = {
 			isa = PBXGroup;
 			children = (
+				FB7522B72A287CC200C051E9 /* PlusTodoViewModelTests.swift */,
 				FBB1445D2A27598800F4D4A2 /* PlanViewModelTests.swift */,
 				FBC20AB22A270F9100EDB6A8 /* PlanManagerViewModelTests.swift */,
 			);
@@ -392,6 +395,7 @@
 			files = (
 				FBC20AB32A270F9100EDB6A8 /* PlanManagerViewModelTests.swift in Sources */,
 				FBB1445E2A27598800F4D4A2 /* PlanViewModelTests.swift in Sources */,
+				FB7522B82A287CC200C051E9 /* PlusTodoViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
+++ b/ProjectManager/ProjectManager.xcodeproj/project.pbxproj
@@ -36,13 +36,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		FBB144582A2758A400F4D4A2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = C7431EFA25F51E1D0094C4CF /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = C7431F0125F51E1D0094C4CF;
-			remoteInfo = ProjectManager;
-		};
 		FBC20AB42A270F9100EDB6A8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C7431EFA25F51E1D0094C4CF /* Project object */;
@@ -64,7 +57,6 @@
 		FB2C68D32A28865E00B9DE55 /* TextColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextColor.swift; sourceTree = "<group>"; };
 		FB7522B52A2869E800C051E9 /* MockPlanSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPlanSubscriber.swift; sourceTree = "<group>"; };
 		FB7522B72A287CC200C051E9 /* PlusTodoViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusTodoViewModelTests.swift; sourceTree = "<group>"; };
-		FBB144542A2758A400F4D4A2 /* PlanViewModelTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PlanViewModelTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FBB1445D2A27598800F4D4A2 /* PlanViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanViewModelTests.swift; sourceTree = "<group>"; };
 		FBC20AA22A1F90AB00EDB6A8 /* PlanManagerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanManagerViewModel.swift; sourceTree = "<group>"; };
 		FBC20AAA2A25B14900EDB6A8 /* PlanSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanSubscriber.swift; sourceTree = "<group>"; };
@@ -89,13 +81,6 @@
 
 /* Begin PBXFrameworksBuildPhase section */
 		C7431EFF25F51E1D0094C4CF /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		FBB144512A2758A400F4D4A2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -128,7 +113,6 @@
 			children = (
 				C7431F0225F51E1D0094C4CF /* ProjectManager.app */,
 				FBC20AB02A270F9100EDB6A8 /* PlanManagerViewModelTests.xctest */,
-				FBB144542A2758A400F4D4A2 /* PlanViewModelTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -235,24 +219,6 @@
 			productReference = C7431F0225F51E1D0094C4CF /* ProjectManager.app */;
 			productType = "com.apple.product-type.application";
 		};
-		FBB144532A2758A400F4D4A2 /* PlanViewModelTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = FBB1445C2A2758A400F4D4A2 /* Build configuration list for PBXNativeTarget "PlanViewModelTests" */;
-			buildPhases = (
-				FBB144502A2758A400F4D4A2 /* Sources */,
-				FBB144512A2758A400F4D4A2 /* Frameworks */,
-				FBB144522A2758A400F4D4A2 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				FBB144592A2758A400F4D4A2 /* PBXTargetDependency */,
-			);
-			name = PlanViewModelTests;
-			productName = PlanViewModelTests;
-			productReference = FBB144542A2758A400F4D4A2 /* PlanViewModelTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 		FBC20AAF2A270F9100EDB6A8 /* PlanManagerViewModelTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = FBC20AB82A270F9100EDB6A8 /* Build configuration list for PBXNativeTarget "PlanManagerViewModelTests" */;
@@ -284,10 +250,6 @@
 					C7431F0125F51E1D0094C4CF = {
 						CreatedOnToolsVersion = 12.4;
 					};
-					FBB144532A2758A400F4D4A2 = {
-						CreatedOnToolsVersion = 14.3;
-						TestTargetID = C7431F0125F51E1D0094C4CF;
-					};
 					FBC20AAF2A270F9100EDB6A8 = {
 						CreatedOnToolsVersion = 14.3;
 						TestTargetID = C7431F0125F51E1D0094C4CF;
@@ -309,7 +271,6 @@
 			targets = (
 				C7431F0125F51E1D0094C4CF /* ProjectManager */,
 				FBC20AAF2A270F9100EDB6A8 /* PlanManagerViewModelTests */,
-				FBB144532A2758A400F4D4A2 /* PlanViewModelTests */,
 			);
 		};
 /* End PBXProject section */
@@ -321,13 +282,6 @@
 			files = (
 				C7431F1225F51E1E0094C4CF /* LaunchScreen.storyboard in Resources */,
 				C7431F0F25F51E1E0094C4CF /* Assets.xcassets in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		FBB144522A2758A400F4D4A2 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -389,13 +343,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBB144502A2758A400F4D4A2 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		FBC20AAC2A270F9100EDB6A8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -410,11 +357,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		FBB144592A2758A400F4D4A2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = C7431F0125F51E1D0094C4CF /* ProjectManager */;
-			targetProxy = FBB144582A2758A400F4D4A2 /* PBXContainerItemProxy */;
-		};
 		FBC20AB52A270F9100EDB6A8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = C7431F0125F51E1D0094C4CF /* ProjectManager */;
@@ -588,50 +530,6 @@
 			};
 			name = Release;
 		};
-		FBB1445A2A2758A400F4D4A2 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
-				MACOSX_DEPLOYMENT_TARGET = 13.1;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = net.riji.PlanViewModelTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ProjectManager.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ProjectManager";
-			};
-			name = Debug;
-		};
-		FBB1445B2A2758A400F4D4A2 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
-				MACOSX_DEPLOYMENT_TARGET = 13.1;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = net.riji.PlanViewModelTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ProjectManager.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ProjectManager";
-			};
-			name = Release;
-		};
 		FBC20AB62A270F9100EDB6A8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -693,15 +591,6 @@
 			buildConfigurations = (
 				C7431F1725F51E1E0094C4CF /* Debug */,
 				C7431F1825F51E1E0094C4CF /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		FBB1445C2A2758A400F4D4A2 /* Build configuration list for PBXNativeTarget "PlanViewModelTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				FBB1445A2A2758A400F4D4A2 /* Debug */,
-				FBB1445B2A2758A400F4D4A2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ProjectManager/ProjectManager.xctestplan
+++ b/ProjectManager/ProjectManager.xctestplan
@@ -1,0 +1,29 @@
+{
+  "configurations" : [
+    {
+      "id" : "867CB75D-B6D9-4312-93DA-3CF5F1F4558D",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:ProjectManager.xcodeproj",
+      "identifier" : "C7431F0125F51E1D0094C4CF",
+      "name" : "ProjectManager"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:ProjectManager.xcodeproj",
+        "identifier" : "FBC20AAF2A270F9100EDB6A8",
+        "name" : "PlanManagerViewModelTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/ProjectManager/ProjectManager/Mock/MockPlanSubscriber.swift
+++ b/ProjectManager/ProjectManager/Mock/MockPlanSubscriber.swift
@@ -9,11 +9,15 @@ import Foundation
 import Combine
 
 final class MockPlanSubscriber: PlanSubscriber {
-    var plans: [Plan]?
+    var plan: [Plan]
     var deletePublisher = PassthroughSubject<Plan, Never>()
     var changePublisher = PassthroughSubject<(Plan, State), Never>()
 
-    func updatePlan(_ plans: [Plan]) {
-        self.plans = plans
+    init(plan: [Plan]) {
+        self.plan = plan
+    }
+    
+    func updatePlan(_ plan: [Plan]) {
+        self.plan = plan
     }
 }

--- a/ProjectManager/ProjectManager/Mock/MockPlanSubscriber.swift
+++ b/ProjectManager/ProjectManager/Mock/MockPlanSubscriber.swift
@@ -1,0 +1,19 @@
+//
+//  MockPlanSubscriber.swift
+//  ProjectManager
+//
+//  Created by 리지 on 2023/06/01.
+//
+
+import Foundation
+import Combine
+
+final class MockPlanSubscriber: PlanSubscriber {
+    var plans: [Plan]?
+    var deletePublisher = PassthroughSubject<Plan, Never>()
+    var changePublisher = PassthroughSubject<(Plan, State), Never>()
+
+    func updatePlan(_ plans: [Plan]) {
+        self.plans = plans
+    }
+}

--- a/ProjectManager/ProjectManager/View/PlanTableViewCell.swift
+++ b/ProjectManager/ProjectManager/View/PlanTableViewCell.swift
@@ -93,8 +93,9 @@ final class PlanTableViewCell: UITableViewCell {
         planTableCellViewModel?.$plan
             .map { plan in
                 plan.date
-            }.sink {
-                self.date.textColor = self.planTableCellViewModel?.selectColor($0)
+            }
+            .sink {
+                self.date.textColor = self.planTableCellViewModel?.selectColor($0).color
                 self.date.text = self.planTableCellViewModel?.convertDate(of: $0)
             }.store(in: &cancellables)
     }

--- a/ProjectManager/ProjectManager/View/TextColor.swift
+++ b/ProjectManager/ProjectManager/View/TextColor.swift
@@ -1,0 +1,22 @@
+//
+//  TextColor.swift
+//  ProjectManager
+//
+//  Created by 리지 on 2023/06/01.
+//
+
+import UIKit
+
+enum TextColor {
+    case red
+    case black
+    
+    var color: UIColor {
+        switch self {
+        case .red:
+            return UIColor.red
+        case .black:
+            return UIColor.black
+        }
+    }
+}

--- a/ProjectManager/ProjectManager/ViewController/PlanViewController.swift
+++ b/ProjectManager/ProjectManager/ViewController/PlanViewController.swift
@@ -65,11 +65,10 @@ final class PlanViewController: UIViewController {
     }
     
     private func configureTableView() {
-        dataSource = UITableViewDiffableDataSource<Section, Plan>(tableView: tableView) { [unowned self] _, indexPath, _ in
+        dataSource = UITableViewDiffableDataSource<Section, Plan>(tableView: tableView) { [unowned self] _, indexPath, itemIdentifier in
             guard let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath) as? PlanTableViewCell else { return UITableViewCell() }
             
-            let plan = viewModel.read(at: indexPath)
-            cell.configureCell(with: plan)
+            cell.configureCell(with: itemIdentifier)
             
             return cell
         }

--- a/ProjectManager/ProjectManager/ViewModel/PlanManagerViewModel.swift
+++ b/ProjectManager/ProjectManager/ViewModel/PlanManagerViewModel.swift
@@ -31,19 +31,19 @@ final class PlanManagerViewModel {
     
     private func bindPlan() {
         $planList
-            .filter { $0.contains { $0.state == .todo }}
+            .map { $0.filter { $0.state == .todo }}
             .sink { [weak self] in
                 self?.todoViewModel.updatePlan($0)
             }
             .store(in: &cancellables)
         $planList
-            .filter { $0.contains { $0.state == .doing }}
+            .map { $0.filter { $0.state == .doing }}
             .sink { [weak self] in
                 self?.doingViewModel.updatePlan($0)
             }
             .store(in: &cancellables)
         $planList
-            .filter { $0.contains { $0.state == .done }}
+            .map { $0.filter { $0.state == .done }}
             .sink { [weak self] in
                 self?.doneViewModel.updatePlan($0)
             }

--- a/ProjectManager/ProjectManager/ViewModel/PlanSubscriber.swift
+++ b/ProjectManager/ProjectManager/ViewModel/PlanSubscriber.swift
@@ -8,7 +8,8 @@
 import Combine
 
 protocol PlanSubscriber {
-    func updatePlan(_ plans: [Plan])
+    var plan: [Plan] { get set }
     var deletePublisher: PassthroughSubject<Plan, Never> { get set }
     var changePublisher: PassthroughSubject<(Plan, State), Never> { get set }
+    func updatePlan(_ plans: [Plan])
 }

--- a/ProjectManager/ProjectManager/ViewModel/PlanTableCellViewModel.swift
+++ b/ProjectManager/ProjectManager/ViewModel/PlanTableCellViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by 리지 on 2023/05/22.
 //
 
-import UIKit
+import Foundation
 import Combine
 
 final class PlanTableCellViewModel {
@@ -19,14 +19,14 @@ final class PlanTableCellViewModel {
         return DateFormatManager.shared.convertToFormattedDate(of: date)
     }
     
-    func selectColor(_ date: Date) -> UIColor {
+    func selectColor(_ date: Date) -> TextColor {
         let result = DateFormatManager.shared.compareDate(from: date)
         
         switch result {
         case .past:
-            return UIColor.red
+            return .red
         default:
-            return UIColor.black
+            return .black
         }
     }
     

--- a/ProjectManager/ProjectManager/ViewModel/PlanViewModel.swift
+++ b/ProjectManager/ProjectManager/ViewModel/PlanViewModel.swift
@@ -14,7 +14,6 @@ final class PlanViewModel: PlanSubscriber {
     var changePublisher = PassthroughSubject<(Plan, State), Never>()
     
     private let state: State
-    private var cancellables = Set<AnyCancellable>()
     
     init(state: State) {
         self.state = state

--- a/ProjectManager/ProjectManagerTests/PlanManagerViewModelTests.swift
+++ b/ProjectManager/ProjectManagerTests/PlanManagerViewModelTests.swift
@@ -1,0 +1,90 @@
+//
+//  PlanManagerViewModelTests.swift
+//  PlanManagerViewModelTests
+//
+//  Created by 리지 on 2023/05/31.
+//
+
+import Combine
+import XCTest
+@testable import ProjectManager
+
+final class PlanManagerViewModelTests: XCTestCase {
+    var sut: PlanManagerViewModel!
+    var planA: Plan?
+    var planB: Plan?
+    var planC: Plan?
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        
+        planA = Plan(title: "산책", body: "강아지 산책시키기", date: Date(), state: .todo)
+        planB = Plan(title: "집안일", body: "설거지, 빨래, 청소기돌리기", date: Date(), state: .todo)
+        planC = Plan(title: "공부", body: "MVC, MVP, MVVM 패턴 공부하기", date: Date(), state: .todo)
+        
+        let todoViewModel = PlanViewModel(state: .todo)
+        let doingViewModel = PlanViewModel(state: .doing)
+        let doneViewModel = PlanViewModel(state: .done)
+        
+        sut = PlanManagerViewModel(
+            todoViewModel: todoViewModel,
+            doingViewModel: doingViewModel,
+            doneViewModel: doneViewModel
+        )
+    }
+    
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        
+        sut = nil
+    }
+    
+    func test_create실행시_planList에값은_nil이아니다() {
+        // given
+        guard let planA = self.planA,
+              let planB = self.planB,
+              let planC = self.planC else { return }
+        
+        sut.create(planA)
+        sut.create(planB)
+        sut.create(planC)
+        
+        // when
+        let result = sut.planList
+        
+        // then
+        XCTAssertNotNil(result)
+    }
+    
+    func test_update실행시_같은id를가진plan이_업데이트된다() {
+        // given
+        guard var planB = self.planB else { return }
+        sut.create(planB)
+        
+        let planBID = planB.id
+        let planBTitle = planB.title
+        let expectationTitle = "NewPlanB"
+        let expectationBody = "뉴플랜B"
+        let expectationState = State.doing
+        
+        // when
+        let title = "NewPlanB"
+        let body = "뉴플랜B"
+        let state = State.doing
+        
+        planB.title = title
+        planB.body = body
+        planB.state = state
+        
+        sut.update(planB)
+        let newPlanB = sut.planList[0]
+        let newPlanBID = newPlanB.id
+        
+        // then
+        XCTAssertEqual(planBID, newPlanBID)
+        XCTAssertEqual(planBTitle, "집안일")
+        XCTAssertEqual(expectationTitle, newPlanB.title)
+        XCTAssertEqual(expectationBody, newPlanB.body)
+        XCTAssertEqual(expectationState, newPlanB.state)
+    }
+}

--- a/ProjectManager/ProjectManagerTests/PlanManagerViewModelTests.swift
+++ b/ProjectManager/ProjectManagerTests/PlanManagerViewModelTests.swift
@@ -17,9 +17,9 @@ final class PlanManagerViewModelTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         
-        mockTodoPlanSubscriber = MockPlanSubscriber()
-        mockDoingPlanSubscriber = MockPlanSubscriber()
-        mockDonePlanSubscriber = MockPlanSubscriber()
+        mockTodoPlanSubscriber = MockPlanSubscriber(plan: [])
+        mockDoingPlanSubscriber = MockPlanSubscriber(plan: [])
+        mockDonePlanSubscriber = MockPlanSubscriber(plan: [])
         
         sut = PlanManagerViewModel(
             todoViewModel: mockTodoPlanSubscriber,

--- a/ProjectManager/ProjectManagerTests/PlanManagerViewModelTests.swift
+++ b/ProjectManager/ProjectManagerTests/PlanManagerViewModelTests.swift
@@ -5,7 +5,6 @@
 //  Created by 리지 on 2023/05/31.
 //
 
-import Combine
 import XCTest
 @testable import ProjectManager
 

--- a/ProjectManager/ProjectManagerTests/PlanTableCellViewModelTests.swift
+++ b/ProjectManager/ProjectManagerTests/PlanTableCellViewModelTests.swift
@@ -1,0 +1,64 @@
+//
+//  PlanTableCellViewModelTests.swift
+//  PlanManagerViewModelTests
+//
+//  Created by 리지 on 2023/06/01.
+//
+
+import XCTest
+@testable import ProjectManager
+final class PlanTableCellViewModelTests: XCTestCase {
+    var sut: PlanTableCellViewModel!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        
+        var plan = Plan(title: "산책", body: "강아지 산책시키기", date: Date(), state: .todo)
+        sut = PlanTableCellViewModel(plan: plan)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+    
+    func test_convertDate호출시_Date가String으로변환한다() {
+        // given
+        let date = Date()
+        let expectation = "2023. 06. 01."
+        
+        // when
+        let result = sut.convertDate(of: date)
+        
+        // then
+        XCTAssertEqual(result, expectation)
+    }
+    
+    func test_selectColor호출시_tense가과거면red를_tense가과거가아니면black을반환한다() {
+        // given
+        let past = Date.distantPast
+        let today = Date()
+        let future = Date.distantFuture
+        
+        // when
+        let pastResult = sut.selectColor(past)
+        let todayResult = sut.selectColor(today)
+        let futureResult = sut.selectColor(future)
+        
+        // then
+        XCTAssertEqual(pastResult, TextColor.red)
+        XCTAssertEqual(todayResult, TextColor.black)
+        XCTAssertEqual(futureResult, TextColor.black)
+    }
+    
+    func test_fetchPlan호출시_plan이반환된다() {
+        // given
+        let expectationTitle = "산책"
+        
+        // when
+        let result = sut.fetchPlan()
+        
+        // then
+        XCTAssertEqual(result.title, expectationTitle)
+    }
+}

--- a/ProjectManager/ProjectManagerTests/PlanTableCellViewModelTests.swift
+++ b/ProjectManager/ProjectManagerTests/PlanTableCellViewModelTests.swift
@@ -10,10 +10,18 @@ import XCTest
 
 final class PlanTableCellViewModelTests: XCTestCase {
     var sut: PlanTableCellViewModel!
+    let dateFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy. MM. dd"
+        return dateFormatter
+    }()
+    
+    var date: Date!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         
+        date = dateFormatter.date(from: "2023. 06. 01")
         let plan = Plan(title: "산책", body: "강아지 산책시키기", date: Date(), state: .todo)
         sut = PlanTableCellViewModel(plan: plan)
     }
@@ -26,7 +34,6 @@ final class PlanTableCellViewModelTests: XCTestCase {
     
     func test_convertDate호출시_Date가String으로변환한다() {
         // given
-        let date = Date()
         let expectation = "2023. 06. 01."
         
         // when

--- a/ProjectManager/ProjectManagerTests/PlanTableCellViewModelTests.swift
+++ b/ProjectManager/ProjectManagerTests/PlanTableCellViewModelTests.swift
@@ -7,18 +7,20 @@
 
 import XCTest
 @testable import ProjectManager
+
 final class PlanTableCellViewModelTests: XCTestCase {
     var sut: PlanTableCellViewModel!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         
-        var plan = Plan(title: "산책", body: "강아지 산책시키기", date: Date(), state: .todo)
+        let plan = Plan(title: "산책", body: "강아지 산책시키기", date: Date(), state: .todo)
         sut = PlanTableCellViewModel(plan: plan)
     }
 
     override func tearDownWithError() throws {
         try super.tearDownWithError()
+        
         sut = nil
     }
     

--- a/ProjectManager/ProjectManagerTests/PlanViewModelTests.swift
+++ b/ProjectManager/ProjectManagerTests/PlanViewModelTests.swift
@@ -11,25 +11,21 @@ import XCTest
 
 final class PlanViewModelTests: XCTestCase {
     var sut: PlanViewModel!
-    var mockSubscriber: MockPlanSubscriber!
     var cancellabels = Set<AnyCancellable>()
     
     override func setUpWithError() throws {
         try super.setUpWithError()
-        sut = PlanViewModel(state: .todo)
-        mockSubscriber = MockPlanSubscriber()
         
+        sut = PlanViewModel(state: .todo)
         let planA = Plan(title: "산책", body: "강아지 산책시키기", date: Date(), state: .todo)
         let planB = Plan(title: "집안일", body: "설거지, 빨래, 청소기돌리기", date: Date(), state: .todo)
         let planC = Plan(title: "공부", body: "MVC, MVP, MVVM 패턴 공부하기", date: Date(), state: .todo)
-        
         sut.plan = [planA, planB, planC]
-        sut.deletePublisher = mockSubscriber.deletePublisher
-        sut.changePublisher = mockSubscriber.changePublisher
     }
 
     override func tearDownWithError() throws {
         try super.tearDownWithError()
+        
         sut = nil
         cancellabels.forEach { $0.cancel() }
     }
@@ -107,7 +103,7 @@ final class PlanViewModelTests: XCTestCase {
         let planToDelete = sut.read(at: indexPath)
         let expectation = expectation(description: "delete")
         
-        mockSubscriber.deletePublisher
+        sut.deletePublisher
             .sink { plan in
                 XCTAssertEqual(plan, planToDelete)
                 expectation.fulfill()
@@ -128,7 +124,7 @@ final class PlanViewModelTests: XCTestCase {
         let newState = State.doing
         let expectation = expectation(description: "change")
         
-        mockSubscriber.changePublisher
+        sut.changePublisher
             .sink { plan, state in
                 XCTAssertEqual(plan, planToChange)
                 XCTAssertEqual(state, newState)
@@ -138,9 +134,8 @@ final class PlanViewModelTests: XCTestCase {
         
         // when
         sut.changeState(plan: planToChange, state: newState)
-        
+       
         // then
         waitForExpectations(timeout: 1)
     }
-
 }

--- a/ProjectManager/ProjectManagerTests/PlanViewModelTests.swift
+++ b/ProjectManager/ProjectManagerTests/PlanViewModelTests.swift
@@ -1,0 +1,146 @@
+//
+//  PlanViewModelTests.swift
+//  PlanManagerViewModelTests
+//
+//  Created by 리지 on 2023/05/31.
+//
+
+import Combine
+import XCTest
+@testable import ProjectManager
+
+final class PlanViewModelTests: XCTestCase {
+    var sut: PlanViewModel!
+    var mockSubscriber: MockPlanSubscriber!
+    var cancellabels = Set<AnyCancellable>()
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = PlanViewModel(state: .todo)
+        mockSubscriber = MockPlanSubscriber()
+        
+        let planA = Plan(title: "산책", body: "강아지 산책시키기", date: Date(), state: .todo)
+        let planB = Plan(title: "집안일", body: "설거지, 빨래, 청소기돌리기", date: Date(), state: .todo)
+        let planC = Plan(title: "공부", body: "MVC, MVP, MVVM 패턴 공부하기", date: Date(), state: .todo)
+        
+        sut.plan = [planA, planB, planC]
+        sut.deletePublisher = mockSubscriber.deletePublisher
+        sut.changePublisher = mockSubscriber.changePublisher
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+        cancellabels.forEach { $0.cancel() }
+    }
+    
+    func test_state가todo일때_firstActionTitle은_doing이고_secondActionTitle은_done이다 () {
+        // given
+        let firstExpectation = "Move to DOING"
+        let secondExpectation = "Move to DONE"
+        
+        // when
+        let firstResult = sut.firstActionTitle
+        let secondResult = sut.secondActionTitle
+        
+        // then
+        XCTAssertEqual(firstExpectation, firstResult)
+        XCTAssertEqual(secondExpectation, secondResult)
+    }
+    
+    func test_state가todo일때_첫번째변경상태는doing이고_두번째변경상태는done이다() {
+        // given
+        let firstState = State.doing
+        let secondState = State.done
+        
+        // when
+        let firstResult = sut.moveToFirst
+        let secondResult = sut.moveToSecond
+        
+        // then
+        XCTAssertEqual(firstState, firstResult)
+        XCTAssertEqual(secondState, secondResult)
+    }
+    
+    func test_numberOfItems실행시_plan배열의count를반환한다() {
+        // given
+        let expectation = 3
+        
+        // when
+        let result = sut.numberOfItems
+        
+        // then
+        XCTAssertEqual(expectation, result)
+    }
+    
+    func test_updatePlan실행시_기존plan이_새로운plan으로_업데이트된다() {
+        // given
+        let newPlanA = Plan(title: "운동", body: "필라테스1시간", date: Date(), state: .doing)
+        let newPlanB = Plan(title: "코드리팩토링", body: "다이어리,계산기앱 리팩토링하기", date: Date(), state: .done)
+        let newPlans: [Plan] = [newPlanA, newPlanB]
+        
+        // when
+        sut.updatePlan(newPlans)
+        let result = sut.plan
+        
+        // then
+        XCTAssertEqual(newPlans, result)
+    }
+    
+    func test_read실행시_indexPath로접근하여_plan을꺼내온다() {
+        // given
+        let indexPath = IndexPath(row: 1, section: 0)
+        let expectationTitle = "집안일"
+        let expectationState = State.todo
+        
+        // when
+        let result = sut.read(at: indexPath)
+        
+        // then
+        XCTAssertEqual(expectationTitle, result.title)
+        XCTAssertEqual(expectationState, result.state)
+    }
+    
+    func test_delete실행시_deletPublisher에값이전달된다() {
+        // given
+        let indexPath = IndexPath(row: 1, section: 0)
+        let planToDelete = sut.read(at: indexPath)
+        let expectation = expectation(description: "delete")
+        
+        mockSubscriber.deletePublisher
+            .sink { plan in
+                XCTAssertEqual(plan, planToDelete)
+                expectation.fulfill()
+            }
+            .store(in: &cancellabels)
+        
+        // when
+        sut.delete(planToDelete)
+        
+        // then
+        waitForExpectations(timeout: 1)
+    }
+    
+    func test_changeState실행시_changePublisher에값이전달된다() {
+        // given
+        let indexPath = IndexPath(row: 1, section: 0)
+        let planToChange = sut.read(at: indexPath)
+        let newState = State.doing
+        let expectation = expectation(description: "change")
+        
+        mockSubscriber.changePublisher
+            .sink { plan, state in
+                XCTAssertEqual(plan, planToChange)
+                XCTAssertEqual(state, newState)
+                expectation.fulfill()
+            }
+            .store(in: &cancellabels)
+        
+        // when
+        sut.changeState(plan: planToChange, state: newState)
+        
+        // then
+        waitForExpectations(timeout: 1)
+    }
+
+}

--- a/ProjectManager/ProjectManagerTests/PlusTodoViewModelTests.swift
+++ b/ProjectManager/ProjectManagerTests/PlusTodoViewModelTests.swift
@@ -10,13 +10,13 @@ import XCTest
 
 final class PlusTodoViewModelTests: XCTestCase {
     var sut: PlusTodoViewModel!
-
-    override func setUpWithError() throws {
-      try super.setUpWithError()
     
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        
         sut = PlusTodoViewModel()
     }
-
+    
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         
@@ -26,7 +26,7 @@ final class PlusTodoViewModelTests: XCTestCase {
     func test_addPlan호출시_현재plan은_nil이아니다() {
         // given
         let plan = Plan(title: "산책", body: "강아지 산책시키기", date: Date(), state: .todo)
-    
+        
         // when
         sut.addPlan(plan)
         
@@ -82,5 +82,4 @@ final class PlusTodoViewModelTests: XCTestCase {
         XCTAssertEqual(result.body, plan.body)
         XCTAssertEqual(result.date, plan.date)
     }
-
 }

--- a/ProjectManager/ProjectManagerTests/PlusTodoViewModelTests.swift
+++ b/ProjectManager/ProjectManagerTests/PlusTodoViewModelTests.swift
@@ -1,0 +1,86 @@
+//
+//  PlusTodoViewModelTests.swift
+//  PlanManagerViewModelTests
+//
+//  Created by 리지 on 2023/06/01.
+//
+
+import XCTest
+@testable import ProjectManager
+
+final class PlusTodoViewModelTests: XCTestCase {
+    var sut: PlusTodoViewModel!
+
+    override func setUpWithError() throws {
+      try super.setUpWithError()
+    
+        sut = PlusTodoViewModel()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        
+        sut = nil
+    }
+    
+    func test_addPlan호출시_현재plan은_nil이아니다() {
+        // given
+        let plan = Plan(title: "산책", body: "강아지 산책시키기", date: Date(), state: .todo)
+    
+        // when
+        sut.addPlan(plan)
+        
+        // then
+        XCTAssertNotNil(sut.currentPlan)
+    }
+    
+    func test_configureInitialPlan호출시_입력된Plan이반환된다() {
+        // given
+        let title = "산책"
+        let body = "강아지 산책시키기"
+        let date = Date()
+        let expectation = Plan(title: "산책", body: "강아지 산책시키기", date: Date(), state: .todo)
+        
+        // when
+        let result = sut.configureInitialPlan(title: title, body: body, date: date)
+        
+        // then
+        XCTAssertEqual(result.title, expectation.title)
+        XCTAssertEqual(result.body, expectation.body)
+        XCTAssertEqual(result.date, expectation.date)
+        XCTAssertEqual(result.state, expectation.state)
+    }
+    
+    func test_updateCurrentPlan호출시_isEdit이참이면_plan값이업데이트된다() {
+        // given
+        let title = "TIL작성"
+        let body = "오늘 학습활동 정리하기"
+        let date = Date()
+        let plan = Plan(title: "산책", body: "강아지 산책시키기", date: Date(), state: .todo)
+        sut.addPlan(plan)
+        sut.changEditMode()
+        
+        // when
+        guard let result = sut.updateCurrentPlan(title: title, body: body, date: date) else { return }
+        
+        // then
+        XCTAssertEqual(result.title, title)
+        XCTAssertEqual(result.body, body)
+        XCTAssertEqual(result.date, date)
+    }
+    
+    func test_fetchCurrentPlan호출시_currentPlan을반환한다() {
+        // given
+        let plan = Plan(title: "산책", body: "강아지 산책시키기", date: Date(), state: .todo)
+        sut.addPlan(plan)
+        
+        // when
+        guard let result = sut.fetchCurrentPlan() else { return }
+        
+        // then
+        XCTAssertEqual(result.title, plan.title)
+        XCTAssertEqual(result.body, plan.body)
+        XCTAssertEqual(result.date, plan.date)
+    }
+
+}


### PR DESCRIPTION
안녕하세요! 올라프(@1Consumption)
사전에 논의했던 대로 ViewModel에 대한 UnitTest를 진행하였습니다. 
이번 PR도 잘 부탁드립니다!
3주동안 많은 도움 주셔서 감사합니다 😀

## 고민했던 점 

### private 메서드 테스트
`PlanManagerViewModel`의 메서드는 대부분 `private` 접근제어가 되어있어 test 객체에서 직접 불러오기 어려운 문제가 있었습니다. 이를 해결하기 위해 `MockPlanSubscriber`객체를 만들어 `publisher`에 값을 넣어주어 테스트할 객체의 메서드가 실행되면 최종 아웃풋으로 비교하는 식으로 테스트를 진행하였습니다.

```swift
import Foundation
import Combine

final class MockPlanSubscriber: PlanSubscriber {
    var plans: [Plan]?
    var deletePublisher = PassthroughSubject<Plan, Never>()
    var changePublisher = PassthroughSubject<(Plan, State), Never>()

    func updatePlan(_ plans: [Plan]) {
        self.plans = plans
    }
}
```

### publisher 테스트

`PlanViewModel`에서 `publisher`에 값을 전달하는 메서드를 확인하기 위해 비동기 테스트시 사용하는 `XCTestExpectation`을 활용하였습니다.

```swift
import Combine
import XCTest
@testable import ProjectManager

final class PlanViewModelTests: XCTestCase {
    var sut: PlanViewModel!
    var cancellabels = Set<AnyCancellable>()
    
    override func setUpWithError() throws {
        try super.setUpWithError()
        
        sut = PlanViewModel(state: .todo)
        ...
    }

    override func tearDownWithError() throws {
        try super.tearDownWithError()
        
        sut = nil
        cancellabels.forEach { $0.cancel() }
    }
    ...
    func test_delete실행시_deletPublisher에값이전달된다() {
        // given
        let indexPath = IndexPath(row: 1, section: 0)
        let planToDelete = sut.read(at: indexPath)
        let expectation = expectation(description: "delete")
        
        sut.deletePublisher
            .sink { plan in
                XCTAssertEqual(plan, planToDelete)
                expectation.fulfill()
            }
            .store(in: &cancellabels)
        
        // when
        sut.delete(planToDelete)
        
        // then
        waitForExpectations(timeout: 1)
    }
}
```
- `planToDelete` : 삭제할 `Plan`을 꺼내옴
- `expectation` : 비동기 테스트에서 예상되는 결과를 나타내는 `XCTestExpectation` 인스턴스
- `expectation.fulfill()` : sut의 `deletePublisher`를 구독하여 plan이 같은지 비교하고 테스트의 비동기 작업이 완료되면 `fulfill()`을 호출한다.
- `waitForExpectations(timeout: 1)` : 작업이 완료되고 1초동안 기다린 후 처리
